### PR TITLE
Extract React specific dependencies into single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 <img src="assets/connect-query@16x.png" width="15%" />
 
 <!-- omit in toc -->
+
 # Connect-Query
 
 [![License](https://img.shields.io/github/license/connectrpc/connect-query-es?color=blue)](./LICENSE) [![Build](https://github.com/connectrpc/connect-query-es/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/connectrpc/connect-query-es/actions/workflows/ci.yaml) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/connect-query/latest?color=green&label=%40connectrpc%2Fconnect-query)](https://www.npmjs.com/package/@connectrpc/connect-query) [![NPM Version](https://img.shields.io/npm/v/@connectrpc/protoc-gen-connect-query/latest?color=green&label=%40connectrpc%2Fprotoc-gen-connect-query)](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-query)
 
-Connect-Query is an expansion pack for [TanStack Query](https://tanstack.com/query) (react-query), written in TypeScript and thoroughly tested.  It enables effortless communication with servers that speak the [Connect Protocol](https://connectrpc.com/docs/protocol).
+Connect-Query is an expansion pack for [TanStack Query](https://tanstack.com/query) (react-query), written in TypeScript and thoroughly tested. It enables effortless communication with servers that speak the [Connect Protocol](https://connectrpc.com/docs/protocol).
 
 - [Quickstart](#quickstart)
   - [Generated Code](#generated-code)
@@ -14,13 +15,15 @@ Connect-Query is an expansion pack for [TanStack Query](https://tanstack.com/que
   - [`createQueryService`](#createqueryservice)
   - [`TransportProvider`](#transportprovider)
   - [`useTransport`](#usetransport)
-  - [`UnaryHooks.createData`](#unaryhookscreatedata)
-  - [`UnaryHooks.createUseQueryOptions`](#unaryhookscreateusequeryoptions)
-  - [`UnaryHooks.getPartialQueryKey`](#unaryhooksgetpartialquerykey)
-  - [`UnaryHooks.getQueryKey`](#unaryhooksgetquerykey)
-  - [`UnaryHooks.methodInfo`](#unaryhooksmethodinfo)
-  - [`UnaryHooks.setQueryData`](#unaryhookssetquerydata)
-  - [`UnaryHooks.setQueriesData`](#unaryhookssetqueriesdata)
+  - [`UnaryFunctions.createData`](#unaryfunctionscreatedata)
+  - [`UnaryFunctions.createUseQueryOptions`](#unaryfunctionscreateusequeryoptions)
+  - [`UnaryFunctions.createUseInfiniteQueryOptions`](#unaryfunctionscreateuseinfinitequeryoptions)
+  - [`UnaryFunctions.createUseMutationOptions`](#unaryfunctionscreateusemutationoptions)
+  - [`UnaryFunctions.getPartialQueryKey`](#unaryfunctionsgetpartialquerykey)
+  - [`UnaryFunctions.getQueryKey`](#unaryfunctionsgetquerykey)
+  - [`UnaryFunctions.methodInfo`](#unaryfunctionsmethodinfo)
+  - [`UnaryFunctions.setQueryData`](#unaryfunctionssetquerydata)
+  - [`UnaryFunctions.setQueriesData`](#unaryfunctionssetqueriesdata)
   - [`UnaryHooks.useInfiniteQuery`](#unaryhooksuseinfinitequery)
   - [`UnaryHooks.useMutation`](#unaryhooksusemutation)
   - [`UnaryHooks.useQuery`](#unaryhooksusequery)
@@ -52,7 +55,7 @@ Note: If you are using something that doesn't automatically install peerDependen
 
 ### Usage
 
-Connect-Query will immediately feel familiar to you if you've used TanStack Query.  It provides a set of convenient helpers that you can pass to the same TanStack Query functions you're already using:
+Connect-Query will immediately feel familiar to you if you've used TanStack Query. It provides a set of convenient helpers that you can pass to the same TanStack Query functions you're already using:
 
 ```ts
 import { useQuery } from '@tanstack/react-query';
@@ -66,9 +69,9 @@ export const Example: FC = () => {
 
 **_That's it!_**
 
-The [code generator](packages/protoc-gen-connect-query/README.md) does all the work of turning your Protobuf file into something you can easily import.  TypeScript types all populate out-of-the-box.  Your documentation is also converted to [TSDoc](https://tsdoc.org/).
+The [code generator](packages/protoc-gen-connect-query/README.md) does all the work of turning your Protobuf file into something you can easily import. TypeScript types all populate out-of-the-box. Your documentation is also converted to [TSDoc](https://tsdoc.org/).
 
-One of the best features of this library is that once you write your schema in Protobuf form, the TypeScript types are generated and then inferred.  You never again need to specify the types of your data since the library does it automatically.
+One of the best features of this library is that once you write your schema in Protobuf form, the TypeScript types are generated and then inferred. You never again need to specify the types of your data since the library does it automatically.
 
 <!-- markdownlint-disable-next-line MD033 -- necessary for centering -->
 <div align="center">
@@ -91,7 +94,7 @@ One of the best features of this library is that once you write your schema in P
 
 ### Generated Code
 
-This example shows the best developer experience using code generation.  Here's what that generated code looks like:
+This example shows the best developer experience using code generation. Here's what that generated code looks like:
 
 ```ts title="your-generated-code/example-ExampleService_connectquery"
 import { createQueryService } from "@connectrpc/connect-query";
@@ -128,14 +131,14 @@ const createQueryService: <Service extends ServiceType>({
 }: {
   service: Service;
   transport?: Transport;
-}) => QueryHooks<Service>
+}) => QueryHooks<Service>;
 ```
 
 `createQueryService` is the main entrypoint for Connect-Query.
 
-Pass in a service and you will receive an object with properties for each of your services and values that provide hooks for those services that you can then give to Tanstack Query.  The `ServiceType` TypeScript interface is provided by Protobuf-ES (`@bufbuild/protobuf`) while generated service definitions are provided by Connect-Web (`@connectrpc/connect-web`).
+Pass in a service and you will receive an object with properties for each of your services and values that provide hooks for those services that you can then give to Tanstack Query. The `ServiceType` TypeScript interface is provided by Protobuf-ES (`@bufbuild/protobuf`) while generated service definitions are provided by Connect-Web (`@connectrpc/connect-web`).
 
-`Transport` refers to the mechanism by which your client will make the actual network calls.  If you want to use a custom transport, you can optionally provide one with a call to `useTransport`, which Connect-Query exports.  Otherwise, the default transport from React context will be used.  This default transport is placed on React context by the `TransportProvider`. Whether you pass a custom transport or you use `TransportProvider`, in both cases you'll need to use one of `@connectrpc/connect-web`'s exports `createConnectTransport` or `createGrpcWebTransport`.
+`Transport` refers to the mechanism by which your client will make the actual network calls. If you want to use a custom transport, you can optionally provide one with a call to `useTransport`, which Connect-Query exports. Otherwise, the default transport from React context will be used. This default transport is placed on React context by the `TransportProvider`. Whether you pass a custom transport or you use `TransportProvider`, in both cases you'll need to use one of `@connectrpc/connect-web`'s exports `createConnectTransport` or `createGrpcWebTransport`.
 
 Note that the most memory performant approach is to use the transport on React Context by using the `TransportProvider` because that provider is memoized by React, but also that any calls to `createQueryService` with the same service is cached by this function.
 
@@ -164,17 +167,19 @@ const { data, isLoading, ...etc } = useQuery(say.useQuery());
 > Note: This API can only be used with React
 
 ```ts
-const TransportProvider: FC<PropsWithChildren<{
-  transport: Transport;
-}>>;
+const TransportProvider: FC<
+  PropsWithChildren<{
+    transport: Transport;
+  }>
+>;
 ```
 
 `TransportProvider` is the main mechanism by which Connect-Query keeps track of the `Transport` used by your application.
 
 Broadly speaking, "transport" joins two concepts:
 
-  1. The protocol of communication.  For this there are two options: the [Connect Protocol](https://connectrpc.com/docs/protocol/), or the [gRPC-Web Protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md).
-  1. The protocol options.  The primary important piece of information here is the `baseUrl`, but there are also other potentially critical options like request credentials and binary wire format encoding options.
+1. The protocol of communication. For this there are two options: the [Connect Protocol](https://connectrpc.com/docs/protocol/), or the [gRPC-Web Protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md).
+1. The protocol options. The primary important piece of information here is the `baseUrl`, but there are also other potentially critical options like request credentials and binary wire format encoding options.
 
 With these two pieces of information in hand, the transport provides the critical mechanism by which your app can make network requests.
 
@@ -212,7 +217,7 @@ const useTransport: () => Transport;
 
 Use this helper to get the default transport that's currently attached to the React context for the calling component.
 
-### `UnaryHooks.createData`
+### `UnaryFunctions.createData`
 
 ```ts
 const createData: (data: PartialMessage<O>) => O;
@@ -220,31 +225,77 @@ const createData: (data: PartialMessage<O>) => O;
 
 Use this to create a data object that can be used as `placeholderData` or initialData.
 
-### `UnaryHooks.createUseQueryOptions`
+### `UnaryFunctions.createUseQueryOptions`
 
 ```ts
 const createUseQueryOptions: (
- input: DisableQuery | PartialMessage<I> | undefined,
- options: {
-   getPlaceholderData?: (enabled: boolean) => PartialMessage<O> | undefined;
-   onError?: (error: ConnectError) => void;
-   transport: Transport;
-   callOptions?: CallOptions | undefined;
- },
+  input: DisableQuery | PartialMessage<I> | undefined,
+  options: {
+    getPlaceholderData?: (enabled: boolean) => PartialMessage<O> | undefined;
+    onError?: (error: ConnectError) => void;
+    transport: Transport;
+    callOptions?: CallOptions | undefined;
+  },
 ) => {
- enabled: boolean;
- queryKey: ConnectQueryKey<I>;
- queryFn: (context?: QueryFunctionContext<ConnectQueryKey<I>>) => Promise<O>;
- placeholderData?: () => O | undefined;
- onError?: (error: ConnectError) => void;
+  enabled: boolean;
+  queryKey: ConnectQueryKey<I>;
+  queryFn: (context?: QueryFunctionContext<ConnectQueryKey<I>>) => Promise<O>;
+  placeholderData?: () => O | undefined;
+  onError?: (error: ConnectError) => void;
 };
 ```
 
-`createUseQueryOptions` is intended to be used with TanStack's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery) hook.  The difference is that `createUseQueryOptions` is not a hook.  Since hooks cannot be called conditionally, it can sometimes be helpful to use `createUseQueryOptions` to prepare an input to TanStack's `useQuery`.
+`createUseQueryOptions` is intended to be used with TanStack's [`useQuery`](https://tanstack.com/query/v4/docs/react/reference/useQuery) hook. The difference is that `createUseQueryOptions` is not a hook. Since hooks cannot be called conditionally, it can sometimes be helpful to use `createUseQueryOptions` to prepare an input to TanStack's `useQuery`.
 
 It is also useful to use alongside TanStack's [`useQueries`](https://tanstack.com/query/v4/docs/react/reference/useQueries) hook since hooks cannot be called in loops.
 
-### `UnaryHooks.getPartialQueryKey`
+### `UnaryFunctions.createUseMutationOptions`
+
+```ts
+const createUseMutationOptions: (options: {
+  onError?: (error: ConnectError) => void;
+  transport?: Transport | undefined;
+  callOptions?: CallOptions | undefined;
+}) => {
+  mutationFn: (
+    input: PartialMessage<I>,
+    context?: QueryFunctionContext<ConnectQueryKey<I>>,
+  ) => Promise<O>;
+  onError?: (error: ConnectError) => void;
+};
+```
+
+`createUseMutationOptions` is intended to be used with TanStack's [`useMutation`](https://tanstack.com/query/v4/docs/react/reference/useMutation) hook. The difference is that `createUseMutationOptions` is not a hook and doesn't read from `TransportProvider` for it's transport.
+
+### `UnaryFunctions.createUseInfiniteQueryOptions`
+
+```ts
+const createUseInfiniteQueryOptions: <ParamKey extends keyof PlainMessage<I>>(
+  input: DisableQuery | PartialMessage<I>,
+  options: {
+    pageParamKey: ParamKey;
+    getNextPageParam: (lastPage: O, allPages: O[]) => unknown;
+    onError?: (error: ConnectError) => void;
+    transport?: Transport | undefined;
+    callOptions?: CallOptions | undefined;
+  },
+) => {
+  enabled: boolean;
+  queryKey: ConnectQueryKey<I>;
+  queryFn: (
+    context: QueryFunctionContext<
+      ConnectQueryKey<I>,
+      PlainMessage<I>[ParamKey]
+    >,
+  ) => Promise<O>;
+  getNextPageParam: GetNextPageParamFunction<O>;
+  onError?: (error: ConnectError) => void;
+};
+```
+
+`createUseInfiniteQueryOptions` is intended to be used with TanStack's [`useInfiniteQuery`](https://tanstack.com/query/v4/docs/react/reference/useInfiniteQuery) hook. The difference is that `createUseInfiniteQueryOptions` is not a hook and doesn't read from `TransportProvider` for it's transport.
+
+### `UnaryFunctions.getPartialQueryKey`
 
 ```ts
 const getPartialQueryKey: () => ConnectPartialQueryKey;
@@ -252,15 +303,17 @@ const getPartialQueryKey: () => ConnectPartialQueryKey;
 
 This helper is useful for getting query keys matching a wider set of queries associated to this Connect `Service`, per TanStack Query's [partial matching](https://tanstack.com/query/v4/docs/react/guides/query-invalidation#query-matching-with-invalidatequeries) mechanism.
 
-### `UnaryHooks.getQueryKey`
+### `UnaryFunctions.getQueryKey`
 
 ```ts
-const getQueryKey: (input?: DisableQuery | PartialMessage<I>) => ConnectQueryKey<I>;
+const getQueryKey: (
+  input?: DisableQuery | PartialMessage<I>,
+) => ConnectQueryKey<I>;
 ```
 
-This helper is useful to manually compute the [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) sent to TanStack Query.  This function has no side effects.
+This helper is useful to manually compute the [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) sent to TanStack Query. This function has no side effects.
 
-### `UnaryHooks.methodInfo`
+### `UnaryFunctions.methodInfo`
 
 ```ts
 const methodInfo: MethodInfoUnary<I, O>;
@@ -268,33 +321,23 @@ const methodInfo: MethodInfoUnary<I, O>;
 
 This is the metadata associated with this method.
 
-### `UnaryHooks.setQueryData`
+### `UnaryFunctions.setQueryData`
 
 ```ts
 const setQueryData: (
-  updater: PartialMessage<O> | (
-    (prev?: O) => PartialMessage<O>
-  ),
+  updater: PartialMessage<O> | ((prev?: O) => PartialMessage<O>),
   input?: PartialMessage<I>,
-) => [
-  queryKey: ConnectQueryKey<I>,
-  updater: (prev?: O) => O | undefined
-];
+) => [queryKey: ConnectQueryKey<I>, updater: (prev?: O) => O | undefined];
 ```
 
 This helper is intended to be used with TanStack Query `QueryClient`'s [`setQueryData`](https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientsetquerydata) function.
 
-### `UnaryHooks.setQueriesData`
+### `UnaryFunctions.setQueriesData`
 
 ```ts
 const setQueriesData: (
-  updater: PartialMessage<O> | (
-    (prev?: O) => PartialMessage<O>
-  ),
-) => [
-  queryKey: ConnectPartialQueryKey,
-  updater: (prev?: O) => O | undefined
-];
+  updater: PartialMessage<O> | ((prev?: O) => PartialMessage<O>),
+) => [queryKey: ConnectPartialQueryKey, updater: (prev?: O) => O | undefined];
 ```
 
 This helper is intended to be used with TanStack Query `QueryClient`'s [`setQueriesData`](https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientsetqueriesdata) function.
@@ -394,7 +437,7 @@ For example, a query key might look like this:
   "example.v1.ExampleService",
   "GetTodos",
   { id: "0fdf2ebe-9a0c-4366-9772-cfb21346c3f9" },
-]
+];
 ```
 
 ### `ConnectPartialQueryKey`
@@ -402,24 +445,18 @@ For example, a query key might look like this:
 This type is useful In situations where you want to use partial matching for TanStack Query `queryKey`s.
 
 ```ts
-type ConnectPartialQueryKey = [
-  serviceTypeName: string,
-  methodName: string,
-];
+type ConnectPartialQueryKey = [serviceTypeName: string, methodName: string];
 ```
 
 For example, a partial query key might look like this:
 
 ```ts
-[
-  "example.v1.ExampleService",
-  "GetTodos",
-]
+["example.v1.ExampleService", "GetTodos"];
 ```
 
 ## Testing
 
-Connect-query (along with all other javascript based connect packages) can be tested with the `createRouterTransport` function from `@connectrpc/connect`.  This function allows you to create a transport that can be used to test your application without needing to make any network requests. We also have a dedicated package, [@connectrpc/connect-playwright](https://github.com/connectrpc/connect-playwright-es) for testing within [playwright](https://playwright.dev/).
+Connect-query (along with all other javascript based connect packages) can be tested with the `createRouterTransport` function from `@connectrpc/connect`. This function allows you to create a transport that can be used to test your application without needing to make any network requests. We also have a dedicated package, [@connectrpc/connect-playwright](https://github.com/connectrpc/connect-playwright-es) for testing within [playwright](https://playwright.dev/).
 
 For playwright, you can see a sample test [here](https://github.com/connectrpc/connect-playwright-es/blob/main/packages/connect-playwright-example/tests/simple.spec.ts).
 
@@ -428,7 +465,7 @@ For playwright, you can see a sample test [here](https://github.com/connectrpc/c
 There is an alternate plugin [`@connectrpc/protoc-gen-connect-query-react`](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-query-react) that you can use if you are using `@tanstack/react-query` only (and is not compatible with other frameworks like Solid). This plugin is currently experimental to see if it provides a better developer experience.
 
 ```tsx
-import { useExampleQuery } from 'your-generated-code/example-ExampleService_connectquery_react';
+import { useExampleQuery } from "your-generated-code/example-ExampleService_connectquery_react";
 
 export const Example: FC = () => {
   const { data } = useExampleQuery({});
@@ -452,32 +489,32 @@ export const Example: FC = () => {
 };
 ```
 
-On line 5, `example.useQuery({})` just returns an object with a few TanStack Query options preconfigured for you (for example, `queryKey` and `queryFn` and `onError`).  All of the Connect-Query hooks APIs work this way, so you can always inspect the TypeScript type to see which specific TanStack query options are configured.
+On line 5, `example.useQuery({})` just returns an object with a few TanStack Query options preconfigured for you (for example, `queryKey` and `queryFn` and `onError`). All of the Connect-Query hooks APIs work this way, so you can always inspect the TypeScript type to see which specific TanStack query options are configured.
 
 That means, that if you want to add extra TanStack Query options, you can simply spread the object resulting from Connect-Query:
 
 ```ts
-  const { data } = useQuery({
-    ...example.useQuery({}),
+const { data } = useQuery({
+  ...example.useQuery({}),
 
-    // Add any extra TanStack Query options here.
-    // TypeScript will ensure they're valid!
-    refetchInterval: 1000,
-  });
+  // Add any extra TanStack Query options here.
+  // TypeScript will ensure they're valid!
+  refetchInterval: 1000,
+});
 ```
 
 > Why does it work this way?
 >
-> You may be familiar with other projects that directly wrap react-query directly (such as tRPC).  We worked with the TanStack team to develop this API and determined that it's most flexible to simply return an options object.
+> You may be familiar with other projects that directly wrap react-query directly (such as tRPC). We worked with the TanStack team to develop this API and determined that it's most flexible to simply return an options object.
 >
-> 1. You have full control over what's actually passed to TanStack Query.  For example, if you have a query where you'd like to modify the `queryKey`, you can do so directly.
-> 1. It provides full transparency into what Connect Query is actually doing.  This means that if you want to see what _exactly_ Connect Query is doing, you can simply inspect the object.  This makes for a much more straightforward experience when you're debugging your app.
+> 1. You have full control over what's actually passed to TanStack Query. For example, if you have a query where you'd like to modify the `queryKey`, you can do so directly.
+> 1. It provides full transparency into what Connect Query is actually doing. This means that if you want to see what _exactly_ Connect Query is doing, you can simply inspect the object. This makes for a much more straightforward experience when you're debugging your app.
 > 1. This means that the resulting call is plain TanStack Query in every way, which means that you can still integrate with any existing TanStack Query plugins or extensions you may already be using.
 > 1. Not wrapping TanStack Query itself means that you can immediately use Connect-Query with any new functionality or options of TanStack Query.
 
 ### Is this ready for production?
 
-Buf has been using Connect-Query in production for some time.  Also, there is 100% mandatory test coverage in this project which covers quite a lot of edge cases.  That said, this package is given a `v0.x` semver to designate that it's a new project, and we want to make sure the API is exactly what our users want before we call it "production ready".  That also means that some parts of the API may change before `v1.0` is reached.
+Buf has been using Connect-Query in production for some time. Also, there is 100% mandatory test coverage in this project which covers quite a lot of edge cases. That said, this package is given a `v0.x` semver to designate that it's a new project, and we want to make sure the API is exactly what our users want before we call it "production ready". That also means that some parts of the API may change before `v1.0` is reached.
 
 ### What is Connect-Query's relationship to Connect-Web and Protobuf-ES?
 
@@ -487,6 +524,7 @@ Here is a high-level overview of how Connect-Query fits in with Connect-Web and 
 <summary>Expand to see a detailed dependency graph</summary>
 
 <!-- markdownlint-disable-next-line MD033 -- 033: necessary for setting the width; -->
+
 <img
   alt="connect-query_dependency_graph"
   src="./assets/connect-query_dependency_graph.png"
@@ -495,11 +533,11 @@ Here is a high-level overview of how Connect-Query fits in with Connect-Web and 
 
 </details>
 
-Your Protobuf files serve as the primary input to the code generators `protoc-gen-connect-query` and `protoc-gen-es`.  Both of these code generators also rely on primitives provided by Protobuf-ES.  The Buf CLI produces the generated output.  The final generated code uses `Transport` from Connect-Web and generates a final Connect-Query API.
+Your Protobuf files serve as the primary input to the code generators `protoc-gen-connect-query` and `protoc-gen-es`. Both of these code generators also rely on primitives provided by Protobuf-ES. The Buf CLI produces the generated output. The final generated code uses `Transport` from Connect-Web and generates a final Connect-Query API.
 
 ### What is `Transport`
 
-`Transport` is a regular JavaScript object with two methods, `unary` and `stream`.  See the definition in the Connect-Web codebase [here](https://github.com/connectrpc/connect-es/blob/main/packages/connect/src/transport.ts).  `Transport` defines the mechanism by which the browser can call a gRPC-web or Connect backend.  Read more about Transport on the [connect docs](https://connectrpc.com/docs/web/choosing-a-protocol).
+`Transport` is a regular JavaScript object with two methods, `unary` and `stream`. See the definition in the Connect-Web codebase [here](https://github.com/connectrpc/connect-es/blob/main/packages/connect/src/transport.ts). `Transport` defines the mechanism by which the browser can call a gRPC-web or Connect backend. Read more about Transport on the [connect docs](https://connectrpc.com/docs/web/choosing-a-protocol).
 
 ### What if I already use Connect-Web?
 
@@ -507,48 +545,27 @@ You can use Connect-Web and Connect-Query together if you like!
 
 ### What if I use gRPC-web?
 
-Connect-Query also supports gRPC-web!  All you need to do is make sure you call `createGrpcWebTransport` instead of `createConnectTransport`.
+Connect-Query also supports gRPC-web! All you need to do is make sure you call `createGrpcWebTransport` instead of `createConnectTransport`.
 
 That said, we encourage you to check out the [Connect protocol](https://connectrpc.com/docs/protocol/), a simple, POST-only protocol that works over HTTP/1.1 or HTTP/2. It supports server-streaming methods just like gRPC-Web, but is easy to debug in the network inspector.
 
 ### Do I have to use a code generator?
 
-No.  The code generator just calls [`createQueryService`](#createqueryservice) with the arguments already added, but you are free to do that yourself if you wish.
+No. The code generator just calls [`createQueryService`](#createqueryservice) with the arguments already added, but you are free to do that yourself if you wish.
 
 ### What if I have a custom `Transport`?
 
-If the `Transport` attached to React Context via the `TransportProvider` isn't working for you, then you can override transport at every level.  For example, you can pass a custom transport directly to the lowest-level API like `UnaryHooks.useQuery`, but you can also pass it to `createQueryHooks` or even as high as `createQueryService`.  It's an optional argument for all of those cases and if you choose to omit the `transport` property, the `Transport` provided by `TransportProvider` will be used (only where necessary).
+If the `Transport` attached to React Context via the `TransportProvider` isn't working for you, then you can override transport at every level. For example, you can pass a custom transport directly to the lowest-level API like `UnaryHooks.useQuery`, but you can also pass it to `createQueryHooks` or even as high as `createQueryService`. It's an optional argument for all of those cases and if you choose to omit the `transport` property, the `Transport` provided by `TransportProvider` will be used (only where necessary).
 
 ### Does this only work with React?
 
-You can use Connect-Query with any TanStack variant (React, Solid, Svelte, Vue).  However, since the hooks APIs like [`UnaryHooks.useQuery`](#unaryhooksusequery) and [`UnaryHooks.useMutation`](#unaryhooksusemutation) automatically infer `Transport` from React Context, these APIs will only work with React, as of now.  There is nothing else React specific in the Connect-Query codebase.  As we expand the scope of the project, we do hope to support all APIs on all TanStack Query variants.
+You can use Connect-Query with any TanStack variant (React, Solid, Svelte, Vue). All methods which are part of the `UnaryFunctions` type can be used by any framework. The only APIs which are React specific are the `TransportProvider`, and any APIs starting with `use`.
 
-| Connect-Query API       | React              | Solid              | Svelte             | Vue             |
-| ----------------------- | ------------------ | ------------------ | ------------------ | ------------------ |
-| `createQueryService`    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `createQueryHooks`      | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `isSupportedMethod`     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `disableQuery`          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `unaryHooks`            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `createData`            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `createUseQueryOptions` | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `getPartialQueryKey`    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `getQueryKey`           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `methodInfo`            | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `setQueryData`          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `setQueriesData`        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| `useInfiniteQuery`      | :heavy_check_mark: | :x:                | :x:                | :x:                |
-| `useMutation`           | :heavy_check_mark: | :x:                | :x:                | :x:                |
-| `useQuery`              | :heavy_check_mark: | :x:                | :x:                | :x:                |
-| `useQuery`              | :heavy_check_mark: | :x:                | :x:                | :x:                |
-| `useTransport`          | :heavy_check_mark: | :x:                | :x:                | :x:                |
-| `TransportProvider`     | :heavy_check_mark: | :x:                | :x:                | :x:                |
-
-> Tip: If you're a TanStack Query user that uses something other than React, we'd love to hear from you.  Please reach out to us on the [Buf Slack](https://buf.build/links/slack).
+> Tip: If you're a TanStack Query user that uses something other than React, we'd love to hear from you. Please reach out to us on the [Buf Slack](https://buf.build/links/slack).
 
 #### SolidJS Example
 
-Say, for example, you're using Solid together with TanStack Query's `useQuery` API.  In this case you can use `UnaryHooks.createUseQueryOptions` instead of `UnaryHooks.useQuery`.  The only difference is that `createUseQueryOptions` requires you to pass in a `Transport` because it is not a hook and hooks are where transport is automatically inferred.
+Say, for example, you're using Solid together with TanStack Query's `useQuery` API. In this case you can use `UnaryFunctions.createUseQueryOptions` instead of `UnaryHooks.useQuery`. The only difference is that `createUseQueryOptions` requires you to pass in a `Transport` because it is not a hook and hooks are where transport is automatically inferred.
 
 Here's an example using SolidJS:
 
@@ -558,14 +575,14 @@ import { getTodos } from "./example-ElizaService_connectquery";
 
 function Component() {
   const options = example.createUseQueryOptions(
-    { name: 'My First Todo' },
-    { transport }
+    { name: "My First Todo" },
+    { transport },
   );
   const query = createQuery({
     ...options,
-    queryKey: () => options.queryKey
+    queryKey: () => options.queryKey,
   });
-  return <div>{whatever}</div>
+  return <div>{whatever}</div>;
 }
 ```
 
@@ -579,7 +596,7 @@ To get started, we invite you to open a pull request with an example project in 
 
 If you're not yet at the point of creating an example project, feel free to open an issue in the repository and describe your use case. We'll follow up with questions to better understand your needs.
 
-Your input and ideas are crucial in shaping the future development of Connect-Query.  We appreciate your input and look forward to hearing from you.
+Your input and ideas are crucial in shaping the future development of Connect-Query. We appreciate your input and look forward to hearing from you.
 
 ## Status
 

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "clean": "rm -rf src/eliza",
+    "clean": "rm -rf src/gen",
     "dev": "vite",
     "generate": "buf generate --path eliza.proto",
     "license-header": "license-header",

--- a/examples/react/basic/src/gen/eliza-BigIntService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-BigIntService_connectquery.ts
@@ -44,12 +44,12 @@ export const BigIntService = {
   },
 } as const;
 
-const queryService = createQueryService({ service: BigIntService });
+const $queryService = createQueryService({ service: BigIntService });
 
 /**
  * @generated from rpc connectrpc.eliza.v1.BigIntService.Count
  */
 export const count = {
-  ...queryService.count,
-  ...createUnaryHooks(queryService.count),
+  ...$queryService.count,
+  ...createUnaryHooks($queryService.count),
 };

--- a/examples/react/basic/src/gen/eliza-BigIntService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-BigIntService_connectquery.ts
@@ -19,7 +19,10 @@
 
 import { CountRequest, CountResponse } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.BigIntService";
 
@@ -48,5 +51,5 @@ const queryService = createQueryService({ service: BigIntService });
  */
 export const count = {
   ...queryService.count,
-  ...createHooks(queryService.count),
+  ...createUnaryHooks(queryService.count),
 };

--- a/examples/react/basic/src/gen/eliza-BigIntService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-BigIntService_connectquery.ts
@@ -19,7 +19,7 @@
 
 import { CountRequest, CountResponse } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.BigIntService";
 
@@ -41,9 +41,12 @@ export const BigIntService = {
   },
 } as const;
 
+const queryService = createQueryService({ service: BigIntService });
+
 /**
  * @generated from rpc connectrpc.eliza.v1.BigIntService.Count
  */
-export const count = createQueryService({
-  service: BigIntService,
-}).count;
+export const count = {
+  ...queryService.count,
+  ...createHooks(queryService.count),
+};

--- a/examples/react/basic/src/gen/eliza-ElizaService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-ElizaService_connectquery.ts
@@ -26,7 +26,10 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.ElizaService";
 
@@ -100,7 +103,10 @@ const queryService = createQueryService({ service: ElizaService });
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = { ...queryService.say, ...createHooks(queryService.say) };
+export const say = {
+  ...queryService.say,
+  ...createUnaryHooks(queryService.say),
+};
 
 /**
  * SayAgain is a unary RPC. Eliza responds to the prompt with a single sentence.
@@ -109,5 +115,5 @@ export const say = { ...queryService.say, ...createHooks(queryService.say) };
  */
 export const sayAgain = {
   ...queryService.sayAgain,
-  ...createHooks(queryService.sayAgain),
+  ...createUnaryHooks(queryService.sayAgain),
 };

--- a/examples/react/basic/src/gen/eliza-ElizaService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-ElizaService_connectquery.ts
@@ -26,7 +26,7 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.ElizaService";
 
@@ -93,20 +93,21 @@ export const ElizaService = {
   },
 } as const;
 
+const queryService = createQueryService({ service: ElizaService });
+
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = createQueryService({
-  service: ElizaService,
-}).say;
+export const say = { ...queryService.say, ...createHooks(queryService.say) };
 
 /**
  * SayAgain is a unary RPC. Eliza responds to the prompt with a single sentence.
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.SayAgain
  */
-export const sayAgain = createQueryService({
-  service: ElizaService,
-}).sayAgain;
+export const sayAgain = {
+  ...queryService.sayAgain,
+  ...createHooks(queryService.sayAgain),
+};

--- a/examples/react/basic/src/gen/eliza-ElizaService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-ElizaService_connectquery.ts
@@ -96,7 +96,7 @@ export const ElizaService = {
   },
 } as const;
 
-const queryService = createQueryService({ service: ElizaService });
+const $queryService = createQueryService({ service: ElizaService });
 
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
@@ -104,8 +104,8 @@ const queryService = createQueryService({ service: ElizaService });
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
 export const say = {
-  ...queryService.say,
-  ...createUnaryHooks(queryService.say),
+  ...$queryService.say,
+  ...createUnaryHooks($queryService.say),
 };
 
 /**
@@ -114,6 +114,6 @@ export const say = {
  * @generated from rpc connectrpc.eliza.v1.ElizaService.SayAgain
  */
 export const sayAgain = {
-  ...queryService.sayAgain,
-  ...createUnaryHooks(queryService.sayAgain),
+  ...$queryService.sayAgain,
+  ...createUnaryHooks($queryService.sayAgain),
 };

--- a/examples/react/basic/src/gen/eliza-Haberdasher_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-Haberdasher_connectquery.ts
@@ -44,12 +44,12 @@ export const Haberdasher = {
   },
 } as const;
 
-const queryService = createQueryService({ service: Haberdasher });
+const $queryService = createQueryService({ service: Haberdasher });
 
 /**
  * @generated from rpc connectrpc.eliza.v1.Haberdasher.Work
  */
 export const work = {
-  ...queryService.work,
-  ...createUnaryHooks(queryService.work),
+  ...$queryService.work,
+  ...createUnaryHooks($queryService.work),
 };

--- a/examples/react/basic/src/gen/eliza-Haberdasher_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-Haberdasher_connectquery.ts
@@ -19,7 +19,7 @@
 
 import { Nothing } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.Haberdasher";
 
@@ -41,9 +41,9 @@ export const Haberdasher = {
   },
 } as const;
 
+const queryService = createQueryService({ service: Haberdasher });
+
 /**
  * @generated from rpc connectrpc.eliza.v1.Haberdasher.Work
  */
-export const work = createQueryService({
-  service: Haberdasher,
-}).work;
+export const work = { ...queryService.work, ...createHooks(queryService.work) };

--- a/examples/react/basic/src/gen/eliza-Haberdasher_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-Haberdasher_connectquery.ts
@@ -19,7 +19,10 @@
 
 import { Nothing } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.Haberdasher";
 
@@ -46,4 +49,7 @@ const queryService = createQueryService({ service: Haberdasher });
 /**
  * @generated from rpc connectrpc.eliza.v1.Haberdasher.Work
  */
-export const work = { ...queryService.work, ...createHooks(queryService.work) };
+export const work = {
+  ...queryService.work,
+  ...createUnaryHooks(queryService.work),
+};

--- a/examples/react/basic/src/gen/eliza-PaginatedService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-PaginatedService_connectquery.ts
@@ -19,7 +19,7 @@
 
 import { ListRequest, ListResponse } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.PaginatedService";
 
@@ -41,9 +41,9 @@ export const PaginatedService = {
   },
 } as const;
 
+const queryService = createQueryService({ service: PaginatedService });
+
 /**
  * @generated from rpc connectrpc.eliza.v1.PaginatedService.List
  */
-export const list = createQueryService({
-  service: PaginatedService,
-}).list;
+export const list = { ...queryService.list, ...createHooks(queryService.list) };

--- a/examples/react/basic/src/gen/eliza-PaginatedService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-PaginatedService_connectquery.ts
@@ -44,12 +44,12 @@ export const PaginatedService = {
   },
 } as const;
 
-const queryService = createQueryService({ service: PaginatedService });
+const $queryService = createQueryService({ service: PaginatedService });
 
 /**
  * @generated from rpc connectrpc.eliza.v1.PaginatedService.List
  */
 export const list = {
-  ...queryService.list,
-  ...createUnaryHooks(queryService.list),
+  ...$queryService.list,
+  ...createUnaryHooks($queryService.list),
 };

--- a/examples/react/basic/src/gen/eliza-PaginatedService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-PaginatedService_connectquery.ts
@@ -19,7 +19,10 @@
 
 import { ListRequest, ListResponse } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.PaginatedService";
 
@@ -46,4 +49,7 @@ const queryService = createQueryService({ service: PaginatedService });
 /**
  * @generated from rpc connectrpc.eliza.v1.PaginatedService.List
  */
-export const list = { ...queryService.list, ...createHooks(queryService.list) };
+export const list = {
+  ...queryService.list,
+  ...createUnaryHooks(queryService.list),
+};

--- a/examples/react/basic/src/gen/eliza-SecondService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-SecondService_connectquery.ts
@@ -26,7 +26,7 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.SecondService";
 
@@ -77,11 +77,11 @@ export const SecondService = {
   },
 } as const;
 
+const queryService = createQueryService({ service: SecondService });
+
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
  *
  * @generated from rpc connectrpc.eliza.v1.SecondService.Say
  */
-export const say = createQueryService({
-  service: SecondService,
-}).say;
+export const say = { ...queryService.say, ...createHooks(queryService.say) };

--- a/examples/react/basic/src/gen/eliza-SecondService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-SecondService_connectquery.ts
@@ -80,7 +80,7 @@ export const SecondService = {
   },
 } as const;
 
-const queryService = createQueryService({ service: SecondService });
+const $queryService = createQueryService({ service: SecondService });
 
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
@@ -88,6 +88,6 @@ const queryService = createQueryService({ service: SecondService });
  * @generated from rpc connectrpc.eliza.v1.SecondService.Say
  */
 export const say = {
-  ...queryService.say,
-  ...createUnaryHooks(queryService.say),
+  ...$queryService.say,
+  ...createUnaryHooks($queryService.say),
 };

--- a/examples/react/basic/src/gen/eliza-SecondService_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-SecondService_connectquery.ts
@@ -26,7 +26,10 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.SecondService";
 
@@ -84,4 +87,7 @@ const queryService = createQueryService({ service: SecondService });
  *
  * @generated from rpc connectrpc.eliza.v1.SecondService.Say
  */
-export const say = { ...queryService.say, ...createHooks(queryService.say) };
+export const say = {
+  ...queryService.say,
+  ...createUnaryHooks(queryService.say),
+};

--- a/examples/react/basic/src/gen/eliza-Slouch_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-Slouch_connectquery.ts
@@ -44,12 +44,12 @@ export const Slouch = {
   },
 } as const;
 
-const queryService = createQueryService({ service: Slouch });
+const $queryService = createQueryService({ service: Slouch });
 
 /**
  * @generated from rpc connectrpc.eliza.v1.Slouch.Work
  */
 export const work = {
-  ...queryService.work,
-  ...createUnaryHooks(queryService.work),
+  ...$queryService.work,
+  ...createUnaryHooks($queryService.work),
 };

--- a/examples/react/basic/src/gen/eliza-Slouch_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-Slouch_connectquery.ts
@@ -19,7 +19,10 @@
 
 import { Nothing } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.Slouch";
 
@@ -46,4 +49,7 @@ const queryService = createQueryService({ service: Slouch });
 /**
  * @generated from rpc connectrpc.eliza.v1.Slouch.Work
  */
-export const work = { ...queryService.work, ...createHooks(queryService.work) };
+export const work = {
+  ...queryService.work,
+  ...createUnaryHooks(queryService.work),
+};

--- a/examples/react/basic/src/gen/eliza-Slouch_connectquery.ts
+++ b/examples/react/basic/src/gen/eliza-Slouch_connectquery.ts
@@ -19,7 +19,7 @@
 
 import { Nothing } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.Slouch";
 
@@ -41,9 +41,9 @@ export const Slouch = {
   },
 } as const;
 
+const queryService = createQueryService({ service: Slouch });
+
 /**
  * @generated from rpc connectrpc.eliza.v1.Slouch.Work
  */
-export const work = createQueryService({
-  service: Slouch,
-}).work;
+export const work = { ...queryService.work, ...createHooks(queryService.work) };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check:spelling": "cspell \"**\" --gitignore",
     "all": "turbo run build generate format test",
     "update-all": "pnpm update --recursive --latest",
-    "format:root": "pnpm run check:spelling && prettier \"*.js\" \"*.ts\" --write --no-error-on-unmatched-pattern"
+    "format:root": "pnpm run check:spelling && prettier \"*.js\" \"*.ts\" \"README.md\" --write --no-error-on-unmatched-pattern"
   },
   "license": "Apache-2.0",
   "licenseHeader": {

--- a/packages/connect-query/src/create-hooks.ts
+++ b/packages/connect-query/src/create-hooks.ts
@@ -1,0 +1,65 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Message } from "@bufbuild/protobuf";
+
+import type { UnaryFunctions } from "./create-unary-functions";
+import { useTransport } from "./use-transport";
+
+/**
+ * All the additional hooks that are unique to React.
+ */
+export interface UnaryHooks<
+  I extends Message<I>,
+  O extends Message<O>,
+  M extends UnaryFunctions<I, O>,
+> {
+  /** The hook version, including transport, of createUseQueryOptions. */
+  useQuery: M["createUseQueryOptions"];
+  /** The hook version, including transport, of createUseMutationOptions. */
+  useMutation: M["createUseMutationOptions"];
+  /** The hook version, including transport, of createUseInfiniteQueryOptions. */
+  useInfiniteQuery: M["createUseInfiniteQueryOptions"];
+}
+
+/**
+ * Creates the hooks for a given set of unary methods.
+ */
+export function createHooks<I extends Message<I>, O extends Message<O>>(
+  unaryMethods: UnaryFunctions<I, O>,
+): UnaryHooks<I, O, UnaryFunctions<I, O>> {
+  return {
+    useQuery: (input, options) => {
+      const transport = useTransport();
+      return unaryMethods.createUseQueryOptions(input, {
+        transport,
+        ...options,
+      });
+    },
+    useInfiniteQuery: (input, options) => {
+      const transport = useTransport();
+      return unaryMethods.createUseInfiniteQueryOptions(input, {
+        transport,
+        ...options,
+      });
+    },
+    useMutation: (options) => {
+      const transport = useTransport();
+      return unaryMethods.createUseMutationOptions({
+        transport,
+        ...options,
+      });
+    },
+  };
+}

--- a/packages/connect-query/src/create-query-functions.test.ts
+++ b/packages/connect-query/src/create-query-functions.test.ts
@@ -22,11 +22,14 @@ import { MethodKind } from "@bufbuild/protobuf";
 import { describe, expect, it, jest } from "@jest/globals";
 
 import type { ConnectQueryKey } from "./connect-query-key";
-import { createQueryHooks, isSupportedMethod } from "./create-query-hooks";
+import {
+  createQueryFunctions,
+  isSupportedMethod,
+} from "./create-query-functions";
+import type { UnaryFunctions } from "./create-unary-functions";
 import { ElizaService } from "./gen/eliza_connect";
 import type { SayRequest, SayResponse } from "./gen/eliza_pb";
 import type { Alike, Equal, Expect, ExpectFalse } from "./jest/test-utils";
-import type { UnaryHooks } from "./unary-hooks";
 import type { DisableQuery } from "./utils";
 
 describe("isSupportedMethod", () => {
@@ -60,7 +63,7 @@ describe("createQueryHooks", () => {
   const service = ElizaService;
 
   it("creates hooks for unary methods", () => {
-    const hooks = createQueryHooks({
+    const hooks = createQueryFunctions({
       service: {
         ...service,
         methods: {
@@ -73,7 +76,7 @@ describe("createQueryHooks", () => {
     });
 
     type ExpectType_Say = Expect<
-      Equal<typeof hooks.say, UnaryHooks<SayRequest, SayResponse>>
+      Equal<typeof hooks.say, UnaryFunctions<SayRequest, SayResponse>>
     >;
 
     type ExpectType_HooksKeys = Expect<
@@ -128,7 +131,7 @@ describe("createQueryHooks", () => {
       },
     };
 
-    const hooks = createQueryHooks({ service: customService });
+    const hooks = createQueryFunctions({ service: customService });
 
     expect(Object.keys(hooks)).toStrictEqual(["Unary"]);
   });
@@ -153,7 +156,7 @@ describe("createQueryHooks", () => {
       },
     };
 
-    const hooks = createQueryHooks({ service: customService });
+    const hooks = createQueryFunctions({ service: customService });
 
     expect(Object.keys(hooks)).toStrictEqual(["Unary"]);
 

--- a/packages/connect-query/src/create-query-functions.test.ts
+++ b/packages/connect-query/src/create-query-functions.test.ts
@@ -104,8 +104,6 @@ describe("createQueryHooks", () => {
       >
     >;
     expect(hooks.say).toHaveProperty("methodInfo", service.methods.say);
-
-    expect(hooks.say).toHaveProperty("useQuery", expect.any(Function));
   });
 
   it("filters out non-unary methods", () => {

--- a/packages/connect-query/src/create-query-service.test.tsx
+++ b/packages/connect-query/src/create-query-service.test.tsx
@@ -36,7 +36,7 @@ describe("createQueryService", () => {
       const { queryFn } = createQueryService({
         service,
         transport,
-      }).say.useQuery(input);
+      }).say.createUseQueryOptions(input, { transport });
       return queryFn();
     }, wrapper());
 
@@ -59,17 +59,20 @@ describe("createQueryService", () => {
       methodName,
       expect.objectContaining({
         methodInfo: service.methods[methodName],
-        useQuery: expect.any(Function),
+        createUseQueryOptions: expect.any(Function),
       }),
     );
   });
 
-  describe("useQuery", () => {
+  describe("createUseQueryOptions", () => {
     it("has the appropriate properties", () => {
       const {
         result: { current: queryOptions },
       } = renderHook(
-        () => createQueryService({ service }).say.useQuery(input),
+        () =>
+          createQueryService({ service }).say.createUseQueryOptions(input, {
+            transport: mockEliza(),
+          }),
         wrapper(),
       );
 

--- a/packages/connect-query/src/create-query-service.ts
+++ b/packages/connect-query/src/create-query-service.ts
@@ -15,10 +15,10 @@
 import type { ServiceType } from "@bufbuild/protobuf";
 import type { Transport } from "@connectrpc/connect";
 
-import type { QueryHooks } from "./create-query-hooks";
-import { createQueryHooks } from "./create-query-hooks";
+import type { QueryFunctions } from "./create-query-functions";
+import { createQueryFunctions } from "./create-query-functions";
 
-const servicesToHooks = new Map<ServiceType, QueryHooks<ServiceType>>();
+const servicesToHooks = new Map<ServiceType, QueryFunctions<ServiceType>>();
 
 /**
  * `createQueryService` is the main entrypoint for Connect-Query.
@@ -45,7 +45,7 @@ const servicesToHooks = new Map<ServiceType, QueryHooks<ServiceType>>();
  *   },
  * });
  *
- * const { data, isLoading, ...etc } = useQuery(say.useQuery());
+ * const { data, isLoading, ...etc } = useQuery(say.createUseQueryOptions());
  */
 export const createQueryService = <Service extends ServiceType>({
   service,
@@ -53,18 +53,20 @@ export const createQueryService = <Service extends ServiceType>({
 }: {
   service: Service;
   transport?: Transport;
-}): QueryHooks<Service> => {
+}): QueryFunctions<Service> => {
   if (transport) {
     // custom transports are not cached
-    return createQueryHooks({
+    return createQueryFunctions({
       service,
       transport,
     });
   }
 
-  let hooks = servicesToHooks.get(service) as QueryHooks<Service> | undefined;
+  let hooks = servicesToHooks.get(service) as
+    | QueryFunctions<Service>
+    | undefined;
   if (!hooks) {
-    hooks = createQueryHooks({ service });
+    hooks = createQueryFunctions({ service });
     servicesToHooks.set(service, hooks);
   }
 

--- a/packages/connect-query/src/create-unary-functions.test.ts
+++ b/packages/connect-query/src/create-unary-functions.test.ts
@@ -110,7 +110,7 @@ describe("createUnaryFunctions", () => {
 
     const sorter = (a: string, b: string) => a.localeCompare(b);
     expect(Object.keys(genSay).sort(sorter)).toStrictEqual(
-      Object.keys(matchers).sort(sorter)
+      Object.keys(matchers).sort(sorter),
     );
 
     expect(genSay).toMatchObject(matchers);
@@ -192,7 +192,7 @@ describe("createUnaryFunctions", () => {
         const { result, rerender } = renderHook(
           () =>
             useQuery(genCount.createUseQueryOptions(request, { transport })),
-          rest
+          rest,
         );
         type ExpectType_Data = Expect<
           Equal<typeof result.current.data, CountResponse | undefined>
@@ -233,9 +233,9 @@ describe("createUnaryFunctions", () => {
             useQuery(
               genCount.createUseQueryOptions(request, {
                 transport: mockBigInt(),
-              })
+              }),
             ),
-          rest
+          rest,
         );
 
         await waitFor(() => {
@@ -245,7 +245,7 @@ describe("createUnaryFunctions", () => {
         expect(result.current.data?.count).toStrictEqual(1n);
 
         queryClient.setQueryData(
-          ...genCount.setQueryData(partialUpdater, request)
+          ...genCount.setQueryData(partialUpdater, request),
         );
         rerender();
 
@@ -256,7 +256,7 @@ describe("createUnaryFunctions", () => {
       it("allows a function updater", async () => {
         /** @returns input + 1n */
         const functionUpdater = (
-          { count }: { count: bigint } = { count: 1n }
+          { count }: { count: bigint } = { count: 1n },
         ) =>
           new BigIntService.methods.count.O({
             count: count + 1n,
@@ -268,9 +268,9 @@ describe("createUnaryFunctions", () => {
             useQuery(
               genCount.createUseQueryOptions(request, {
                 transport: mockBigInt(),
-              })
+              }),
             ),
-          rest
+          rest,
         );
 
         type ExpectType_Data = Expect<
@@ -284,7 +284,7 @@ describe("createUnaryFunctions", () => {
         expect(result.current.data?.count).toStrictEqual(1n);
 
         queryClient.setQueryData(
-          ...genCount.setQueryData(functionUpdater, request)
+          ...genCount.setQueryData(functionUpdater, request),
         );
         rerender();
 
@@ -326,7 +326,7 @@ describe("createUnaryFunctions", () => {
               context: QueryFunctionContext<
                 ConnectQueryKey<CountRequest>,
                 bigint | undefined
-              >
+              >,
             ) => Promise<CountResponse>;
             getNextPageParam: GetNextPageParamFunction<CountResponse>;
             onError?: (error: ConnectError) => void;
@@ -359,10 +359,10 @@ describe("createUnaryFunctions", () => {
                   pageParamKey: "sentence",
                   getNextPageParam: () => "0",
                   transport: mockTransportOption,
-                }
-              )
+                },
+              ),
             ),
-          wrapper({}, mockTransportContext)
+          wrapper({}, mockTransportContext),
         );
 
         await waitFor(() => {
@@ -370,7 +370,7 @@ describe("createUnaryFunctions", () => {
         });
 
         expect(result.current.data?.pages[0].sentence).toStrictEqual(
-          "override"
+          "override",
         );
       });
 
@@ -381,10 +381,10 @@ describe("createUnaryFunctions", () => {
             {
               getNextPageParam: (lastPage) => lastPage.count + 1n,
               pageParamKey: "add",
-            }
+            },
           );
         }).toThrow(
-          "Invalid assertion: createUseInfiniteQueryOptions requires you to provide a Transport."
+          "Invalid assertion: createUseInfiniteQueryOptions requires you to provide a Transport.",
         );
       });
     });
@@ -399,9 +399,9 @@ describe("createUnaryFunctions", () => {
               pageParamKey: "page",
               getNextPageParam: (lastPage) => lastPage.page + 1n,
               transport: mockPaginatedTransport(),
-            })
+            }),
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       expect(result.current.data).toStrictEqual(undefined);
@@ -460,13 +460,13 @@ describe("createUnaryFunctions", () => {
             getNextPageParam: (lastPage) => lastPage.count,
             transport: mockEliza(),
           }),
-        wrapper()
+        wrapper(),
       );
 
       expect(result.current).toHaveProperty("enabled", false);
 
       await expect(result.current.queryFn).rejects.toThrow(
-        "Invalid assertion: queryFn does not accept a disabled query"
+        "Invalid assertion: queryFn does not accept a disabled query",
       );
     });
 
@@ -480,7 +480,7 @@ describe("createUnaryFunctions", () => {
             getNextPageParam,
             transport: mockBigInt(),
           }),
-        wrapper()
+        wrapper(),
       );
 
       expect(result.current.getNextPageParam).toStrictEqual(getNextPageParam);
@@ -508,9 +508,9 @@ describe("createUnaryFunctions", () => {
                 pageParamKey: "add",
                 getNextPageParam: (lastPage) => lastPage.count,
                 transport: mockEliza(),
-              }
+              },
             ),
-          wrapper()
+          wrapper(),
         );
         expect(result.current.onError).toBeUndefined();
         expect(consoleErrorSpy).not.toHaveBeenCalled();
@@ -524,12 +524,12 @@ describe("createUnaryFunctions", () => {
               ...genCount.createUseInfiniteQueryOptions(
                 // @ts-expect-error(2345) intentionally invalid input
                 { nope: "nope nope" },
-                { onError, pageParamKey: "add", transport: mockEliza() }
+                { onError, pageParamKey: "add", transport: mockEliza() },
               ),
               queryFn: async () => Promise.reject("error"),
               retry: false,
             }),
-          wrapper(undefined, mockBigInt())
+          wrapper(undefined, mockBigInt()),
         );
         rerender();
 
@@ -560,10 +560,10 @@ describe("createUnaryFunctions", () => {
                 getNextPageParam: (lastPage) => lastPage.count,
                 transport,
                 callOptions: mockCallOptions,
-              }
-            )
+              },
+            ),
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       expect(transportSpy).toHaveBeenCalledWith(
@@ -572,7 +572,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.signal, // signal
         mockCallOptions.timeoutMs, // timeoutMs
         mockCallOptions.headers, // headers
-        expect.anything() // input
+        expect.anything(), // input
       );
     });
 
@@ -589,10 +589,10 @@ describe("createUnaryFunctions", () => {
                 getNextPageParam: (lastPage) => lastPage.page + 1n,
                 transport,
                 callOptions: mockCallOptions,
-              }
-            )
+              },
+            ),
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       expect(transportSpy).toHaveBeenCalledWith(
@@ -603,7 +603,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.headers, // headers
         expect.objectContaining({
           page: 1n,
-        }) // input
+        }), // input
       );
     });
 
@@ -626,10 +626,10 @@ describe("createUnaryFunctions", () => {
                   // @ts-expect-error(2345) ignore these errors for testing
                   ...input,
                 }),
-              }
-            )
+              },
+            ),
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
     });
 
@@ -644,9 +644,9 @@ describe("createUnaryFunctions", () => {
               getNextPageParam: (lastPage) => lastPage.page + 1n,
               transport,
               callOptions: mockCallOptions,
-            }
+            },
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       expect(result.current.queryKey).toStrictEqual([
@@ -681,9 +681,9 @@ describe("createUnaryFunctions", () => {
               getNextPageParam: (lastPage) => lastPage.page + 1n,
               transport,
               callOptions: mockCallOptions,
-            }
+            },
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       expect(result.current.queryKey).toStrictEqual([
@@ -719,10 +719,10 @@ describe("createUnaryFunctions", () => {
                 getNextPageParam: (lastPage) => lastPage.page + 1n,
                 transport,
                 callOptions: mockCallOptions,
-              }
-            )
+              },
+            ),
           ),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       expect(transportSpy).toHaveBeenCalledWith(
@@ -733,7 +733,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.headers, // headers
         expect.objectContaining({
           page: 2n,
-        }) // input
+        }), // input
       );
     });
   });
@@ -756,9 +756,9 @@ describe("createUnaryFunctions", () => {
           useMutation(
             customSay.createUseMutationOptions({
               transport: mockTransportOption,
-            })
+            }),
           ),
-        wrapper({}, mockTransportContext)
+        wrapper({}, mockTransportContext),
       );
 
       result.current.mutate({});
@@ -776,7 +776,7 @@ describe("createUnaryFunctions", () => {
       expect(() => {
         genCount.createUseMutationOptions();
       }).toThrow(
-        "Invalid assertion: createUseMutationOptions requires you to provide a Transport."
+        "Invalid assertion: createUseMutationOptions requires you to provide a Transport.",
       );
     });
 
@@ -807,7 +807,7 @@ describe("createUnaryFunctions", () => {
               input: PartialMessage<CountRequest>,
               context?:
                 | QueryFunctionContext<ConnectQueryKey<CountRequest>>
-                | undefined
+                | undefined,
             ) => Promise<CountResponse>;
             onError?: (error: ConnectError) => void;
           }
@@ -819,11 +819,11 @@ describe("createUnaryFunctions", () => {
           genCount.createUseMutationOptions({
             transport: mockBigInt(),
           }),
-        wrapper()
+        wrapper(),
       );
 
       expect(
-        Object.keys(result.current).sort((a, b) => a.localeCompare(b))
+        Object.keys(result.current).sort((a, b) => a.localeCompare(b)),
       ).toStrictEqual(["mutationFn"]);
     });
 
@@ -841,7 +841,7 @@ describe("createUnaryFunctions", () => {
             mutationFn: async () => Promise.reject("error"),
             mutationKey: genCount.getQueryKey(),
           }),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       rerender();
@@ -871,7 +871,7 @@ describe("createUnaryFunctions", () => {
 
       const { queryClient, transport, ...rest } = wrapper(
         { defaultOptions },
-        mockStatefulBigIntTransport()
+        mockStatefulBigIntTransport(),
       );
       const { result } = renderHook(
         () => ({
@@ -886,17 +886,17 @@ describe("createUnaryFunctions", () => {
                 queryClient.getQueryData<CountResponse>(queryKey) ?? {};
 
               queryClient.setQueryData(
-                ...genCount.setQueryData({ count: count + input.add }, input)
+                ...genCount.setQueryData({ count: count + input.add }, input),
               );
             },
           }),
           get: useQuery(
             genCount.createUseQueryOptions(input, {
               transport,
-            })
+            }),
           ),
         }),
-        rest
+        rest,
       );
 
       type ExpectType_MutationFn = Expect<
@@ -943,7 +943,7 @@ describe("createUnaryFunctions", () => {
             }),
             mutationKey: genCount.getQueryKey({ add: 1n }),
           }),
-        wrapper({ defaultOptions })
+        wrapper({ defaultOptions }),
       );
 
       result.current.mutate({ add: 2n });
@@ -958,7 +958,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.signal, // signal
         mockCallOptions.timeoutMs, // timeoutMs
         mockCallOptions.headers, // headers
-        expect.anything() // input
+        expect.anything(), // input
       );
     });
   });
@@ -978,7 +978,7 @@ describe("createUnaryFunctions", () => {
           params[1],
           | {
               getPlaceholderData?: (
-                enabled: boolean
+                enabled: boolean,
               ) => PartialMessage<SayResponse> | undefined;
               onError?: (error: ConnectError) => void;
               transport?: Transport | undefined;
@@ -999,7 +999,7 @@ describe("createUnaryFunctions", () => {
             enabled: boolean;
             queryKey: ConnectQueryKey<SayRequest>;
             queryFn: (
-              context?: QueryFunctionContext<ConnectQueryKey<SayRequest>>
+              context?: QueryFunctionContext<ConnectQueryKey<SayRequest>>,
             ) => Promise<SayResponse>;
             placeholderData?: () => SayResponse | undefined;
             onError?: (error: ConnectError) => void;
@@ -1014,7 +1014,7 @@ describe("createUnaryFunctions", () => {
       });
 
       expect(
-        Object.keys(result).sort((a, b) => a.localeCompare(b))
+        Object.keys(result).sort((a, b) => a.localeCompare(b)),
       ).toStrictEqual([
         "enabled",
         "onError",
@@ -1031,7 +1031,7 @@ describe("createUnaryFunctions", () => {
           {},
           {
             transport: mockEliza(),
-          }
+          },
         );
         type ExpectType_Expect = Expect<Equal<typeof result.enabled, boolean>>;
       });
@@ -1041,7 +1041,7 @@ describe("createUnaryFunctions", () => {
           {},
           {
             transport: mockEliza(),
-          }
+          },
         );
 
         expect(result).toHaveProperty("enabled", true);
@@ -1114,7 +1114,7 @@ describe("createUnaryFunctions", () => {
       it("will use pass the value of `enabled` to the getPlaceholderData callback", () => {
         const getPlaceholderData = jest.fn<
           (
-            enabled?: boolean | undefined
+            enabled?: boolean | undefined,
           ) => PartialMessage<SayResponse> | undefined
         >(() => ({}));
         const { result } = renderHook(
@@ -1123,9 +1123,9 @@ describe("createUnaryFunctions", () => {
               genSay.createUseQueryOptions(disableQuery, {
                 getPlaceholderData,
                 transport: mockEliza(),
-              })
+              }),
             ),
-          wrapper()
+          wrapper(),
         );
 
         expect(result.current.data?.sentence).toStrictEqual("");
@@ -1135,7 +1135,7 @@ describe("createUnaryFunctions", () => {
       it("will be undefined if getPlaceholderData returns undefined", () => {
         const getPlaceholderData = jest.fn<
           (
-            enabled?: boolean | undefined
+            enabled?: boolean | undefined,
           ) => PartialMessage<SayResponse> | undefined
         >(() => undefined);
         const { result } = renderHook(
@@ -1144,9 +1144,9 @@ describe("createUnaryFunctions", () => {
               genSay.createUseQueryOptions(disableQuery, {
                 getPlaceholderData,
                 transport: mockEliza(),
-              })
+              }),
             ),
-          wrapper()
+          wrapper(),
         );
 
         expect(result.current.data?.sentence).toStrictEqual(undefined);
@@ -1177,12 +1177,12 @@ describe("createUnaryFunctions", () => {
               ...genSay.createUseQueryOptions(
                 // @ts-expect-error(2345) intentionally invalid input
                 { nope: "nope nope" },
-                { onError, transport: mockEliza() }
+                { onError, transport: mockEliza() },
               ),
               queryFn: async () => Promise.reject("error"),
               retry: false,
             }),
-          wrapper()
+          wrapper(),
         );
         rerender();
 
@@ -1214,7 +1214,7 @@ describe("createUnaryFunctions", () => {
             (
               context?:
                 | QueryFunctionContext<ConnectQueryKey<SayRequest>>
-                | undefined
+                | undefined,
             ) => Promise<SayResponse>
           >
         >;
@@ -1235,8 +1235,8 @@ describe("createUnaryFunctions", () => {
 
         await expect(result.queryFn).rejects.toStrictEqual(
           new Error(
-            "Invalid assertion: queryFn does not accept a disabled query"
-          )
+            "Invalid assertion: queryFn does not accept a disabled query",
+          ),
         );
       });
 
@@ -1251,10 +1251,10 @@ describe("createUnaryFunctions", () => {
                 {
                   transport,
                   callOptions: mockCallOptions,
-                }
-              )
+                },
+              ),
             ),
-          wrapper()
+          wrapper(),
         );
 
         expect(transportSpy).toHaveBeenCalledWith(
@@ -1263,7 +1263,7 @@ describe("createUnaryFunctions", () => {
           mockCallOptions.signal, // signal
           mockCallOptions.timeoutMs, // timeoutMs
           mockCallOptions.headers, // headers
-          expect.anything() // input
+          expect.anything(), // input
         );
       });
     });

--- a/packages/connect-query/src/create-unary-functions.test.ts
+++ b/packages/connect-query/src/create-unary-functions.test.ts
@@ -40,6 +40,7 @@ import type {
   ConnectPartialQueryKey,
   ConnectQueryKey,
 } from "./connect-query-key";
+import { createUnaryFunctions } from "./create-unary-functions";
 import { defaultOptions } from "./default-options";
 import {
   BigIntService,
@@ -58,28 +59,27 @@ import {
   sleep,
   wrapper,
 } from "./jest/test-utils";
-import { unaryHooks } from "./unary-hooks";
 import type { DisableQuery } from "./utils";
 import { disableQuery } from "./utils";
 
 const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-const genCount = unaryHooks({
+const genCount = createUnaryFunctions({
   methodInfo: BigIntService.methods.count,
   typeName: BigIntService.typeName,
 });
 
-const genSay = unaryHooks({
+const genSay = createUnaryFunctions({
   methodInfo: ElizaService.methods.say,
   typeName: ElizaService.typeName,
 });
 
-const genPaginated = unaryHooks({
+const genPaginated = createUnaryFunctions({
   methodInfo: PaginatedService.methods.list,
   typeName: PaginatedService.typeName,
 });
 
-describe("unaryHooks", () => {
+describe("createUnaryFunctions", () => {
   it("produces the intended API surface", () => {
     type ExpectType_sayKeys = Expect<
       Equal<
@@ -120,7 +120,7 @@ describe("unaryHooks", () => {
 
   it("throws when provided non unary services", () => {
     expect(() => {
-      unaryHooks({
+      createUnaryFunctions({
         methodInfo: {
           ...ElizaService.methods.say,
           // @ts-expect-error(2322) intentionally incorrect
@@ -128,7 +128,7 @@ describe("unaryHooks", () => {
         },
         service: ElizaService,
       });
-    }).toThrow("unaryHooks was passed a non unary method, Say");
+    }).toThrow("createUnaryFunctions was passed a non unary method, Say");
   });
 
   it("uses a custom transport", async () => {
@@ -469,7 +469,7 @@ describe("unaryHooks", () => {
         const mockTransportOption = mockEliza({
           sentence: "override",
         });
-        const customSay = unaryHooks({
+        const customSay = createUnaryFunctions({
           methodInfo: ElizaService.methods.say,
           typeName: ElizaService.typeName,
           transport: mockTransportTopLevel,
@@ -854,7 +854,7 @@ describe("unaryHooks", () => {
         sentence: "mockTransportOption",
       });
 
-      const customSay = unaryHooks({
+      const customSay = createUnaryFunctions({
         methodInfo: ElizaService.methods.say,
         typeName: ElizaService.typeName,
         transport: mockTransportTopLevel,

--- a/packages/connect-query/src/create-unary-functions.test.ts
+++ b/packages/connect-query/src/create-unary-functions.test.ts
@@ -85,15 +85,14 @@ describe("createUnaryFunctions", () => {
       Equal<
         keyof typeof genSay,
         | "createData"
+        | "createUseInfiniteQueryOptions"
+        | "createUseMutationOptions"
         | "createUseQueryOptions"
         | "getPartialQueryKey"
         | "getQueryKey"
         | "methodInfo"
         | "setQueriesData"
         | "setQueryData"
-        | "useInfiniteQuery"
-        | "useMutation"
-        | "useQuery"
       >
     >;
 
@@ -105,9 +104,8 @@ describe("createUnaryFunctions", () => {
       methodInfo: expect.objectContaining(ElizaService.methods.say),
       setQueriesData: expect.any(Function),
       setQueryData: expect.any(Function),
-      useInfiniteQuery: expect.any(Function),
-      useQuery: expect.any(Function),
-      useMutation: expect.any(Function),
+      createUseInfiniteQueryOptions: expect.any(Function),
+      createUseMutationOptions: expect.any(Function),
     };
 
     const sorter = (a: string, b: string) => a.localeCompare(b);
@@ -135,14 +133,11 @@ describe("createUnaryFunctions", () => {
     const input = { sentence: "ziltoid" } satisfies PartialMessage<SayRequest>;
     const transport = mockEliza();
 
-    const { result } = renderHook(
-      async () => {
-        const { queryFn } = genSay.useQuery(input);
+    const { result } = renderHook(async () => {
+      const { queryFn } = genSay.createUseQueryOptions(input, { transport });
 
-        return queryFn();
-      },
-      wrapper({}, transport),
-    );
+      return queryFn();
+    });
 
     const response = await result.current;
 
@@ -157,133 +152,6 @@ describe("createUnaryFunctions", () => {
       const expected = new BigIntService.methods.count.O(partial);
 
       expect(genCount.createData(partial)).toStrictEqual(expected);
-    });
-  });
-
-  // note: the bulk of this helper is tested via the API's main entry point: `useQuery`, which simply calls this function with automatic inference of transport.
-  describe("createUseQueryOptions", () => {
-    it("has the intended API surface", () => {
-      type ExpectType_CreateUserQueryOptionsParams = Expect<
-        Equal<Parameters<typeof genCount.createUseQueryOptions>["length"], 2>
-      >;
-      type ExpectType_CreateUserQueryOptionsParams0 = Expect<
-        Equal<
-          Parameters<typeof genCount.createUseQueryOptions>[0],
-          DisableQuery | PartialMessage<CountRequest> | undefined
-        >
-      >;
-      type ExpectType_CreateUserQueryOptionsParams1 = Expect<
-        Equal<
-          Parameters<typeof genCount.createUseQueryOptions>[1],
-          {
-            getPlaceholderData?: (
-              enabled: boolean,
-            ) => PartialMessage<CountResponse> | undefined;
-            onError?: (error: ConnectError) => void;
-            transport: Transport;
-            callOptions?: CallOptions | undefined;
-          }
-        >
-      >;
-      type ExpectType_CreateUserQueryOptionsReturn = Expect<
-        Equal<
-          ReturnType<typeof genCount.createUseQueryOptions>,
-          {
-            enabled: boolean;
-            queryKey: ConnectQueryKey<CountRequest>;
-            queryFn: (
-              context?:
-                | QueryFunctionContext<ConnectQueryKey<CountRequest>>
-                | undefined,
-            ) => Promise<CountResponse>;
-            placeholderData?: () => CountResponse | undefined;
-            onError?: (error: ConnectError) => void;
-          }
-        >
-      >;
-
-      expect.assertions(0);
-    });
-
-    it("requires transport", () => {
-      const message =
-        "createUseQueryOptions requires you to provide a Transport.  If you want automatic inference of Transport, try using the useQuery helper.";
-      expect(() =>
-        genCount.createUseQueryOptions(
-          {},
-          {
-            // @ts-expect-error(2322) intentionally incorrect
-            transport: undefined,
-          },
-        ),
-      ).toThrow(`Invalid assertion: ${message}`);
-      expect(() =>
-        genCount.createUseQueryOptions(
-          {},
-          // @ts-expect-error(2322) intentionally incorrect
-          {},
-        ),
-      ).toThrow(`Invalid assertion: ${message}`);
-    });
-  });
-
-  describe("getPartialQueryKey", () => {
-    type ExpectType_GetQuery = Expect<
-      Equal<typeof genSay.getPartialQueryKey, () => ConnectPartialQueryKey>
-    >;
-
-    it("returns a partial query key", () => {
-      expect(genSay.getPartialQueryKey()).toStrictEqual([
-        "connectrpc.eliza.v1.ElizaService",
-        "Say",
-      ]);
-    });
-  });
-
-  describe("getQueryKey", () => {
-    type ExpectType_GetQuery = Expect<
-      Equal<
-        typeof genSay.getQueryKey,
-        (
-          input?: DisableQuery | PartialMessage<SayRequest>,
-        ) => ConnectQueryKey<SayRequest>
-      >
-    >;
-
-    it("returns a simple query key with an input", () => {
-      const sentence = { sentence: "ziltoid" };
-      expect(genSay.getQueryKey(sentence)).toStrictEqual([
-        "connectrpc.eliza.v1.ElizaService",
-        "Say",
-        sentence,
-      ]);
-    });
-
-    it("returns handles disableQuery", () => {
-      expect(genSay.getQueryKey(disableQuery)).toStrictEqual([
-        "connectrpc.eliza.v1.ElizaService",
-        "Say",
-        {},
-      ]);
-    });
-
-    it("returns handles no input", () => {
-      expect(genSay.getQueryKey()).toStrictEqual([
-        "connectrpc.eliza.v1.ElizaService",
-        "Say",
-        {},
-      ]);
-      expect(genSay.getQueryKey(undefined)).toStrictEqual([
-        "connectrpc.eliza.v1.ElizaService",
-        "Say",
-        {},
-      ]);
-      // @ts-expect-error(2345) intentionally incorrect
-      expect(genSay.getQueryKey(null)).toStrictEqual([
-        "connectrpc.eliza.v1.ElizaService",
-        "Say",
-        {},
-      ]);
     });
   });
 
@@ -322,7 +190,8 @@ describe("createUnaryFunctions", () => {
         const { queryClient, ...rest } = wrapper({ defaultOptions });
 
         const { result, rerender } = renderHook(
-          () => useQuery(genCount.useQuery(request, { transport })),
+          () =>
+            useQuery(genCount.createUseQueryOptions(request, { transport })),
           rest,
         );
         type ExpectType_Data = Expect<
@@ -357,13 +226,15 @@ describe("createUnaryFunctions", () => {
       });
 
       it("allows a partial message updater", async () => {
-        const { queryClient, ...rest } = wrapper(
-          { defaultOptions },
-          mockBigInt(),
-        );
+        const { queryClient, ...rest } = wrapper({ defaultOptions });
 
         const { result, rerender } = renderHook(
-          () => useQuery(genCount.useQuery(request)),
+          () =>
+            useQuery(
+              genCount.createUseQueryOptions(request, {
+                transport: mockBigInt(),
+              }),
+            ),
           rest,
         );
 
@@ -391,12 +262,14 @@ describe("createUnaryFunctions", () => {
             count: count + 1n,
           });
 
-        const { queryClient, ...rest } = wrapper(
-          { defaultOptions },
-          mockBigInt(),
-        );
+        const { queryClient, ...rest } = wrapper({ defaultOptions });
         const { result, rerender } = renderHook(
-          () => useQuery(genCount.useQuery(request)),
+          () =>
+            useQuery(
+              genCount.createUseQueryOptions(request, {
+                transport: mockBigInt(),
+              }),
+            ),
           rest,
         );
 
@@ -423,7 +296,7 @@ describe("createUnaryFunctions", () => {
 
   describe("useInfiniteQuery", () => {
     it("has the intended API surface", () => {
-      type params = Parameters<typeof genCount.useInfiniteQuery>;
+      type params = Parameters<typeof genCount.createUseInfiniteQueryOptions>;
       type ExpectType_UseInfiniteQueryParamsLength = Expect<
         Equal<params["length"], 2>
       >;
@@ -432,7 +305,9 @@ describe("createUnaryFunctions", () => {
         Equal<params[0], DisableQuery | PartialMessage<CountRequest>>
       >;
 
-      type returnType = ReturnType<typeof genCount.useInfiniteQuery>;
+      type returnType = ReturnType<
+        typeof genCount.createUseInfiniteQueryOptions
+      >;
 
       type ExpectType_UseInfiniteQueryReturnKeys = Expect<
         Equal<
@@ -478,7 +353,7 @@ describe("createUnaryFunctions", () => {
         const { result } = renderHook(
           () =>
             useInfiniteQuery(
-              customSay.useInfiniteQuery(
+              customSay.createUseInfiniteQueryOptions(
                 { sentence: "Infinity" },
                 {
                   pageParamKey: "sentence",
@@ -498,6 +373,18 @@ describe("createUnaryFunctions", () => {
           "override",
         );
       });
+
+      it("requires a transport", () => {
+        expect(() => {
+          genCount.createUseInfiniteQueryOptions(
+            {},
+            {
+              getNextPageParam: (lastPage) => lastPage.count + 1n,
+              pageParamKey: "add",
+            },
+          );
+        }).toThrow("Transport must be provided");
+      });
     });
 
     it("integrates with `useInfiniteQuery`", async () => {
@@ -506,12 +393,13 @@ describe("createUnaryFunctions", () => {
       const { result, rerender } = renderHook(
         () =>
           useInfiniteQuery(
-            genPaginated.useInfiniteQuery(input, {
+            genPaginated.createUseInfiniteQueryOptions(input, {
               pageParamKey: "page",
               getNextPageParam: (lastPage) => lastPage.page + 1n,
+              transport: mockPaginatedTransport(),
             }),
           ),
-        wrapper({ defaultOptions }, mockPaginatedTransport()),
+        wrapper({ defaultOptions }),
       );
 
       expect(result.current.data).toStrictEqual(undefined);
@@ -565,9 +453,10 @@ describe("createUnaryFunctions", () => {
     it("is disabled when input matches the `disableQuery` symbol", async () => {
       const { result } = renderHook(
         () =>
-          genCount.useInfiniteQuery(disableQuery, {
+          genCount.createUseInfiniteQueryOptions(disableQuery, {
             pageParamKey: "add",
             getNextPageParam: (lastPage) => lastPage.count,
+            transport: mockEliza(),
           }),
         wrapper(),
       );
@@ -584,7 +473,7 @@ describe("createUnaryFunctions", () => {
       const getNextPageParam = (lastPage: CountResponse) => lastPage.count;
       const { result } = renderHook(
         () =>
-          genCount.useInfiniteQuery(input, {
+          genCount.createUseInfiniteQueryOptions(input, {
             pageParamKey: "add",
             getNextPageParam,
             transport: mockBigInt(),
@@ -611,11 +500,12 @@ describe("createUnaryFunctions", () => {
       it("doesn't use onError if it isn't passed", () => {
         const { result } = renderHook(
           () =>
-            genCount.useInfiniteQuery(
+            genCount.createUseInfiniteQueryOptions(
               {},
               {
                 pageParamKey: "add",
                 getNextPageParam: (lastPage) => lastPage.count,
+                transport: mockEliza(),
               },
             ),
           wrapper(),
@@ -629,15 +519,15 @@ describe("createUnaryFunctions", () => {
         const { result, rerender } = renderHook(
           () =>
             useQuery({
-              ...genCount.useInfiniteQuery(
+              ...genCount.createUseInfiniteQueryOptions(
                 // @ts-expect-error(2345) intentionally invalid input
                 { nope: "nope nope" },
-                { onError, pageParamKey: "add" },
+                { onError, pageParamKey: "add", transport: mockEliza() },
               ),
               queryFn: async () => Promise.reject("error"),
               retry: false,
             }),
-          wrapper(),
+          wrapper(undefined, mockBigInt()),
         );
         rerender();
 
@@ -661,7 +551,7 @@ describe("createUnaryFunctions", () => {
       renderHook(
         () =>
           useInfiniteQuery(
-            genCount.useInfiniteQuery(
+            genCount.createUseInfiniteQueryOptions(
               { add: 1n },
               {
                 pageParamKey: "add",
@@ -690,7 +580,7 @@ describe("createUnaryFunctions", () => {
       renderHook(
         () =>
           useInfiniteQuery(
-            genPaginated.useInfiniteQuery(
+            genPaginated.createUseInfiniteQueryOptions(
               { page: 1n },
               {
                 pageParamKey: "page",
@@ -721,7 +611,7 @@ describe("createUnaryFunctions", () => {
       renderHook(
         () =>
           useInfiniteQuery(
-            genPaginated.useInfiniteQuery(
+            genPaginated.createUseInfiniteQueryOptions(
               { page: 1n },
               // @ts-expect-error(2345) intentionally invalid applyPageParam + pageParamKey
               {
@@ -745,7 +635,7 @@ describe("createUnaryFunctions", () => {
       const transport = mockPaginatedTransport();
       const { result } = renderHook(
         () =>
-          genPaginated.useInfiniteQuery(
+          genPaginated.createUseInfiniteQueryOptions(
             { page: 1n },
             {
               pageParamKey: "page",
@@ -770,7 +660,7 @@ describe("createUnaryFunctions", () => {
       const transport = mockPaginatedTransport();
       const { result } = renderHook(
         () =>
-          genPaginated.useInfiniteQuery(
+          genPaginated.createUseInfiniteQueryOptions(
             { page: 1n },
             {
               applyPageParam: ({ pageParam, input }) => {
@@ -809,7 +699,7 @@ describe("createUnaryFunctions", () => {
       renderHook(
         () =>
           useInfiniteQuery(
-            genPaginated.useInfiniteQuery(
+            genPaginated.createUseInfiniteQueryOptions(
               { page: 1n },
               {
                 applyPageParam: ({ pageParam, input }) => {
@@ -862,7 +752,9 @@ describe("createUnaryFunctions", () => {
       const { result } = renderHook(
         () =>
           useMutation(
-            customSay.useMutation({ transport: mockTransportOption }),
+            customSay.createUseMutationOptions({
+              transport: mockTransportOption,
+            }),
           ),
         wrapper({}, mockTransportContext),
       );
@@ -878,8 +770,14 @@ describe("createUnaryFunctions", () => {
       });
     });
 
+    it("requires a transport", () => {
+      expect(() => {
+        genCount.createUseMutationOptions();
+      }).toThrow("Transport must be provided");
+    });
+
     it("has the intended API surface", () => {
-      type params = Parameters<typeof genCount.useMutation>;
+      type params = Parameters<typeof genCount.createUseMutationOptions>;
 
       type ExpectType_UseMutationParamsLength = Expect<
         Equal<params["length"], 0 | 1>
@@ -899,7 +797,7 @@ describe("createUnaryFunctions", () => {
 
       type ExpectType_UseMutationReturn = Expect<
         Equal<
-          ReturnType<typeof genCount.useMutation>,
+          ReturnType<typeof genCount.createUseMutationOptions>,
           {
             mutationFn: (
               input: PartialMessage<CountRequest>,
@@ -912,7 +810,13 @@ describe("createUnaryFunctions", () => {
         >
       >;
 
-      const { result } = renderHook(() => genCount.useMutation(), wrapper());
+      const { result } = renderHook(
+        () =>
+          genCount.createUseMutationOptions({
+            transport: mockBigInt(),
+          }),
+        wrapper(),
+      );
 
       expect(
         Object.keys(result.current).sort((a, b) => a.localeCompare(b)),
@@ -926,11 +830,14 @@ describe("createUnaryFunctions", () => {
       const { result, rerender } = renderHook(
         () =>
           useMutation({
-            ...genCount.useMutation({ onError }),
+            ...genCount.createUseMutationOptions({
+              onError,
+              transport: mockBigInt(),
+            }),
             mutationFn: async () => Promise.reject("error"),
             mutationKey: genCount.getQueryKey(),
           }),
-        wrapper({ defaultOptions }, mockBigInt()),
+        wrapper({ defaultOptions }),
       );
 
       rerender();
@@ -958,15 +865,16 @@ describe("createUnaryFunctions", () => {
       /** this input will add one to the total count */
       const input = { add: 2n };
 
-      const { queryClient, ...rest } = wrapper(
+      const { queryClient, transport, ...rest } = wrapper(
         { defaultOptions },
         mockStatefulBigIntTransport(),
       );
-
       const { result } = renderHook(
         () => ({
           mut: useMutation({
-            ...genCount.useMutation(),
+            ...genCount.createUseMutationOptions({
+              transport,
+            }),
             mutationKey: genCount.getQueryKey(input),
             onSuccess: () => {
               const queryKey = genCount.getQueryKey(input);
@@ -978,7 +886,11 @@ describe("createUnaryFunctions", () => {
               );
             },
           }),
-          get: useQuery(genCount.useQuery(input)),
+          get: useQuery(
+            genCount.createUseQueryOptions(input, {
+              transport,
+            }),
+          ),
         }),
         rest,
       );
@@ -1021,7 +933,7 @@ describe("createUnaryFunctions", () => {
       const { result } = renderHook(
         () =>
           useMutation({
-            ...genCount.useMutation({
+            ...genCount.createUseMutationOptions({
               callOptions: mockCallOptions,
               transport,
             }),
@@ -1047,9 +959,9 @@ describe("createUnaryFunctions", () => {
     });
   });
 
-  describe("useQuery", () => {
+  describe("createUseQueryOptions", () => {
     it("has the intended API surface", () => {
-      type params = Parameters<typeof genSay.useQuery>;
+      type params = Parameters<typeof genSay.createUseQueryOptions>;
       type ExpectType_UseQueryParams0 = Expect<
         Equal<
           params[0],
@@ -1078,7 +990,7 @@ describe("createUnaryFunctions", () => {
 
       type ExpectType_UseQueryK = Expect<
         Equal<
-          ReturnType<typeof genSay.useQuery>,
+          ReturnType<typeof genSay.createUseQueryOptions>,
           {
             enabled: boolean;
             queryKey: ConnectQueryKey<SayRequest>;
@@ -1091,17 +1003,14 @@ describe("createUnaryFunctions", () => {
         >
       >;
 
-      const { result } = renderHook(
-        () =>
-          genSay.useQuery(undefined, {
-            onError: jest.fn(),
-            getPlaceholderData: jest.fn(() => new SayResponse()),
-          }),
-        wrapper(),
-      );
+      const result = genSay.createUseQueryOptions(undefined, {
+        onError: jest.fn(),
+        getPlaceholderData: jest.fn(() => new SayResponse()),
+        transport: mockEliza(),
+      });
 
       expect(
-        Object.keys(result.current).sort((a, b) => a.localeCompare(b)),
+        Object.keys(result).sort((a, b) => a.localeCompare(b)),
       ).toStrictEqual([
         "enabled",
         "onError",
@@ -1111,63 +1020,43 @@ describe("createUnaryFunctions", () => {
       ]);
     });
 
-    describe("transport", () => {
-      it("prioritizes option transport", async () => {
-        const mockTransportContext = mockEliza();
-        const mockTransportTopLevel = mockEliza();
-        const mockTransportOption = mockEliza({
-          sentence: "override",
-        });
-        const input = { sentence: "useQuery" };
-        const customSay = unaryHooks({
-          methodInfo: ElizaService.methods.say,
-          typeName: ElizaService.typeName,
-          transport: mockTransportTopLevel,
-        });
-        const { result } = renderHook(
-          () =>
-            useQuery(
-              customSay.useQuery(input, { transport: mockTransportOption }),
-            ),
-          wrapper({}, mockTransportContext),
-        );
-
-        await waitFor(() => {
-          expect(result.current.isSuccess).toBeTruthy();
-        });
-
-        expect(result.current.data?.sentence).toStrictEqual("override");
-      });
-    });
-
     describe("enabled", () => {
       it("has the correct type", () => {
         expect.assertions(0);
-        const { result } = renderHook(() => genSay.useQuery({}), wrapper());
-        type ExpectType_Expect = Expect<
-          Equal<typeof result.current.enabled, boolean>
-        >;
+        const result = genSay.createUseQueryOptions(
+          {},
+          {
+            transport: mockEliza(),
+          },
+        );
+        type ExpectType_Expect = Expect<Equal<typeof result.enabled, boolean>>;
       });
 
       it("is enabled when input does not match the `disableQuery` symbol", () => {
-        const { result } = renderHook(() => genSay.useQuery({}), wrapper());
+        const result = genSay.createUseQueryOptions(
+          {},
+          {
+            transport: mockEliza(),
+          },
+        );
 
-        expect(result.current).toHaveProperty("enabled", true);
+        expect(result).toHaveProperty("enabled", true);
       });
 
       it("is enabled with an empty input", () => {
-        const { result } = renderHook(() => genSay.useQuery(), wrapper());
+        const result = genSay.createUseQueryOptions(undefined, {
+          transport: mockEliza(),
+        });
 
-        expect(result.current).toHaveProperty("enabled", true);
+        expect(result).toHaveProperty("enabled", true);
       });
 
       it("is disabled when input matches the `disableQuery` symbol", () => {
-        const { result } = renderHook(
-          () => genSay.useQuery(disableQuery),
-          wrapper(),
-        );
+        const result = genSay.createUseQueryOptions(disableQuery, {
+          transport: mockEliza(),
+        });
 
-        expect(result.current).toHaveProperty("enabled", false);
+        expect(result).toHaveProperty("enabled", false);
       });
     });
 
@@ -1180,10 +1069,12 @@ describe("createUnaryFunctions", () => {
 
       it("has the correct type", () => {
         expect.assertions(0);
-        const { result } = renderHook(() => genSay.useQuery(), wrapper());
+        const result = genSay.createUseQueryOptions(undefined, {
+          transport: mockEliza(),
+        });
         type ExpectType_GetPlaceholderData = Expect<
           Equal<
-            typeof result.current.placeholderData,
+            typeof result.placeholderData,
             (() => SayResponse | undefined) | undefined
           >
         >;
@@ -1191,19 +1082,16 @@ describe("createUnaryFunctions", () => {
 
       it("passes through getPlaceholderData, when provided", () => {
         const getPlaceholderData = jest.fn(() => placeholderSentence);
-        const { result } = renderHook(
-          () => genSay.useQuery(input, { getPlaceholderData }),
-          wrapper(),
-        );
+        const result = genSay.createUseQueryOptions(input, {
+          getPlaceholderData,
+          transport: mockEliza(),
+        });
 
-        expect(result.current).toHaveProperty(
-          "placeholderData",
-          expect.any(Function),
-        );
+        expect(result).toHaveProperty("placeholderData", expect.any(Function));
         expect(getPlaceholderData).not.toHaveBeenCalled();
 
         const response = (
-          result.current.placeholderData as () => Message<SayResponse>
+          result.placeholderData as () => Message<SayResponse>
         )();
 
         expect(getPlaceholderData).toHaveBeenCalledWith(true);
@@ -1212,9 +1100,11 @@ describe("createUnaryFunctions", () => {
       });
 
       it("does not pass through getPlaceholderData if not provided", () => {
-        const { result } = renderHook(() => genSay.useQuery(input), wrapper());
+        const result = genSay.createUseQueryOptions(input, {
+          transport: mockEliza(),
+        });
 
-        expect(result.current).not.toHaveProperty("getPlaceholderData");
+        expect(result).not.toHaveProperty("getPlaceholderData");
       });
 
       it("will use pass the value of `enabled` to the getPlaceholderData callback", () => {
@@ -1224,7 +1114,13 @@ describe("createUnaryFunctions", () => {
           ) => PartialMessage<SayResponse> | undefined
         >(() => ({}));
         const { result } = renderHook(
-          () => useQuery(genSay.useQuery(disableQuery, { getPlaceholderData })),
+          () =>
+            useQuery(
+              genSay.createUseQueryOptions(disableQuery, {
+                getPlaceholderData,
+                transport: mockEliza(),
+              }),
+            ),
           wrapper(),
         );
 
@@ -1239,7 +1135,13 @@ describe("createUnaryFunctions", () => {
           ) => PartialMessage<SayResponse> | undefined
         >(() => undefined);
         const { result } = renderHook(
-          () => useQuery(genSay.useQuery(disableQuery, { getPlaceholderData })),
+          () =>
+            useQuery(
+              genSay.createUseQueryOptions(disableQuery, {
+                getPlaceholderData,
+                transport: mockEliza(),
+              }),
+            ),
           wrapper(),
         );
 
@@ -1257,8 +1159,10 @@ describe("createUnaryFunctions", () => {
       });
 
       it("doesn't use onError if it isn't passed", () => {
-        const { result } = renderHook(() => genSay.useQuery(), wrapper());
-        expect(result.current.onError).toBeUndefined();
+        const result = genSay.createUseQueryOptions(undefined, {
+          transport: mockEliza(),
+        });
+        expect(result.onError).toBeUndefined();
       });
 
       it("allows for a passthrough onError", async () => {
@@ -1266,8 +1170,11 @@ describe("createUnaryFunctions", () => {
         const { result, rerender } = renderHook(
           () =>
             useQuery({
-              // @ts-expect-error(2345) intentionally invalid input
-              ...genSay.useQuery({ nope: "nope nope" }, { onError }),
+              ...genSay.createUseQueryOptions(
+                // @ts-expect-error(2345) intentionally invalid input
+                { nope: "nope nope" },
+                { onError, transport: mockEliza() },
+              ),
               queryFn: async () => Promise.reject("error"),
               retry: false,
             }),
@@ -1294,10 +1201,12 @@ describe("createUnaryFunctions", () => {
 
       it("has the correct type", () => {
         expect.assertions(0);
-        const { result } = renderHook(() => genSay.useQuery(), wrapper());
+        const result = genSay.createUseQueryOptions(undefined, {
+          transport: mockEliza(),
+        });
         type ExpectType_QueryFn = Expect<
           Equal<
-            typeof result.current.queryFn,
+            typeof result.queryFn,
             (
               context?:
                 | QueryFunctionContext<ConnectQueryKey<SayRequest>>
@@ -1308,18 +1217,19 @@ describe("createUnaryFunctions", () => {
       });
 
       it("generates a query function", () => {
-        const { result } = renderHook(() => genSay.useQuery(input), wrapper());
+        const result = genSay.createUseQueryOptions(input, {
+          transport: mockEliza(),
+        });
 
-        expect(result.current).toHaveProperty("queryFn", expect.any(Function));
+        expect(result).toHaveProperty("queryFn", expect.any(Function));
       });
 
       it("throws when the `queryFn` is passed `disabledQuery` symbol as an input", async () => {
-        const { result } = renderHook(
-          () => genSay.useQuery(disableQuery),
-          wrapper(),
-        );
+        const result = genSay.createUseQueryOptions(disableQuery, {
+          transport: mockEliza(),
+        });
 
-        await expect(result.current.queryFn).rejects.toStrictEqual(
+        await expect(result.queryFn).rejects.toStrictEqual(
           new Error(
             "Invalid assertion: queryFn does not accept a disabled query",
           ),
@@ -1332,7 +1242,7 @@ describe("createUnaryFunctions", () => {
         renderHook(
           () =>
             useQuery(
-              genSay.useQuery(
+              genSay.createUseQueryOptions(
                 {},
                 {
                   transport,
@@ -1359,24 +1269,44 @@ describe("createUnaryFunctions", () => {
 
       it("has the correct type", () => {
         expect.assertions(0);
-        const { result } = renderHook(() => genSay.useQuery(), wrapper());
+        const result = genSay.createUseQueryOptions(undefined, {
+          transport: mockEliza(),
+        });
+
         type ExpectType_QueryKey = Expect<
           Equal<
-            typeof result.current.queryKey,
+            typeof result.queryKey,
             [string, string, PartialMessage<SayRequest>]
           >
         >;
       });
 
       it("generates a query key", () => {
-        const { result } = renderHook(() => genSay.useQuery(input), wrapper());
+        const result = genSay.createUseQueryOptions(input, {
+          transport: mockEliza(),
+        });
 
-        expect(result.current).toHaveProperty("queryKey", [
+        expect(result).toHaveProperty("queryKey", [
           ElizaService.typeName,
           ElizaService.methods.say.name,
           { sentence: "ziltoid" },
         ]);
       });
+    });
+  });
+
+  describe("getPartialQueryKey", () => {
+    it("has the return type and value", () => {
+      const key = genSay.getPartialQueryKey();
+
+      type ExpectType_GetPartialQueryKey = Expect<
+        Equal<typeof key, [string, string]>
+      >;
+
+      expect(key).toStrictEqual([
+        ElizaService.typeName,
+        ElizaService.methods.say.name,
+      ]);
     });
   });
 });

--- a/packages/connect-query/src/create-unary-functions.test.ts
+++ b/packages/connect-query/src/create-unary-functions.test.ts
@@ -110,7 +110,7 @@ describe("createUnaryFunctions", () => {
 
     const sorter = (a: string, b: string) => a.localeCompare(b);
     expect(Object.keys(genSay).sort(sorter)).toStrictEqual(
-      Object.keys(matchers).sort(sorter),
+      Object.keys(matchers).sort(sorter)
     );
 
     expect(genSay).toMatchObject(matchers);
@@ -192,7 +192,7 @@ describe("createUnaryFunctions", () => {
         const { result, rerender } = renderHook(
           () =>
             useQuery(genCount.createUseQueryOptions(request, { transport })),
-          rest,
+          rest
         );
         type ExpectType_Data = Expect<
           Equal<typeof result.current.data, CountResponse | undefined>
@@ -233,9 +233,9 @@ describe("createUnaryFunctions", () => {
             useQuery(
               genCount.createUseQueryOptions(request, {
                 transport: mockBigInt(),
-              }),
+              })
             ),
-          rest,
+          rest
         );
 
         await waitFor(() => {
@@ -245,7 +245,7 @@ describe("createUnaryFunctions", () => {
         expect(result.current.data?.count).toStrictEqual(1n);
 
         queryClient.setQueryData(
-          ...genCount.setQueryData(partialUpdater, request),
+          ...genCount.setQueryData(partialUpdater, request)
         );
         rerender();
 
@@ -256,7 +256,7 @@ describe("createUnaryFunctions", () => {
       it("allows a function updater", async () => {
         /** @returns input + 1n */
         const functionUpdater = (
-          { count }: { count: bigint } = { count: 1n },
+          { count }: { count: bigint } = { count: 1n }
         ) =>
           new BigIntService.methods.count.O({
             count: count + 1n,
@@ -268,9 +268,9 @@ describe("createUnaryFunctions", () => {
             useQuery(
               genCount.createUseQueryOptions(request, {
                 transport: mockBigInt(),
-              }),
+              })
             ),
-          rest,
+          rest
         );
 
         type ExpectType_Data = Expect<
@@ -284,7 +284,7 @@ describe("createUnaryFunctions", () => {
         expect(result.current.data?.count).toStrictEqual(1n);
 
         queryClient.setQueryData(
-          ...genCount.setQueryData(functionUpdater, request),
+          ...genCount.setQueryData(functionUpdater, request)
         );
         rerender();
 
@@ -326,7 +326,7 @@ describe("createUnaryFunctions", () => {
               context: QueryFunctionContext<
                 ConnectQueryKey<CountRequest>,
                 bigint | undefined
-              >,
+              >
             ) => Promise<CountResponse>;
             getNextPageParam: GetNextPageParamFunction<CountResponse>;
             onError?: (error: ConnectError) => void;
@@ -359,10 +359,10 @@ describe("createUnaryFunctions", () => {
                   pageParamKey: "sentence",
                   getNextPageParam: () => "0",
                   transport: mockTransportOption,
-                },
-              ),
+                }
+              )
             ),
-          wrapper({}, mockTransportContext),
+          wrapper({}, mockTransportContext)
         );
 
         await waitFor(() => {
@@ -370,7 +370,7 @@ describe("createUnaryFunctions", () => {
         });
 
         expect(result.current.data?.pages[0].sentence).toStrictEqual(
-          "override",
+          "override"
         );
       });
 
@@ -381,9 +381,11 @@ describe("createUnaryFunctions", () => {
             {
               getNextPageParam: (lastPage) => lastPage.count + 1n,
               pageParamKey: "add",
-            },
+            }
           );
-        }).toThrow("Transport must be provided");
+        }).toThrow(
+          "Invalid assertion: createUseInfiniteQueryOptions requires you to provide a Transport."
+        );
       });
     });
 
@@ -397,9 +399,9 @@ describe("createUnaryFunctions", () => {
               pageParamKey: "page",
               getNextPageParam: (lastPage) => lastPage.page + 1n,
               transport: mockPaginatedTransport(),
-            }),
+            })
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       expect(result.current.data).toStrictEqual(undefined);
@@ -458,13 +460,13 @@ describe("createUnaryFunctions", () => {
             getNextPageParam: (lastPage) => lastPage.count,
             transport: mockEliza(),
           }),
-        wrapper(),
+        wrapper()
       );
 
       expect(result.current).toHaveProperty("enabled", false);
 
       await expect(result.current.queryFn).rejects.toThrow(
-        "Invalid assertion: queryFn does not accept a disabled query",
+        "Invalid assertion: queryFn does not accept a disabled query"
       );
     });
 
@@ -478,7 +480,7 @@ describe("createUnaryFunctions", () => {
             getNextPageParam,
             transport: mockBigInt(),
           }),
-        wrapper(),
+        wrapper()
       );
 
       expect(result.current.getNextPageParam).toStrictEqual(getNextPageParam);
@@ -506,9 +508,9 @@ describe("createUnaryFunctions", () => {
                 pageParamKey: "add",
                 getNextPageParam: (lastPage) => lastPage.count,
                 transport: mockEliza(),
-              },
+              }
             ),
-          wrapper(),
+          wrapper()
         );
         expect(result.current.onError).toBeUndefined();
         expect(consoleErrorSpy).not.toHaveBeenCalled();
@@ -522,12 +524,12 @@ describe("createUnaryFunctions", () => {
               ...genCount.createUseInfiniteQueryOptions(
                 // @ts-expect-error(2345) intentionally invalid input
                 { nope: "nope nope" },
-                { onError, pageParamKey: "add", transport: mockEliza() },
+                { onError, pageParamKey: "add", transport: mockEliza() }
               ),
               queryFn: async () => Promise.reject("error"),
               retry: false,
             }),
-          wrapper(undefined, mockBigInt()),
+          wrapper(undefined, mockBigInt())
         );
         rerender();
 
@@ -558,10 +560,10 @@ describe("createUnaryFunctions", () => {
                 getNextPageParam: (lastPage) => lastPage.count,
                 transport,
                 callOptions: mockCallOptions,
-              },
-            ),
+              }
+            )
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       expect(transportSpy).toHaveBeenCalledWith(
@@ -570,7 +572,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.signal, // signal
         mockCallOptions.timeoutMs, // timeoutMs
         mockCallOptions.headers, // headers
-        expect.anything(), // input
+        expect.anything() // input
       );
     });
 
@@ -587,10 +589,10 @@ describe("createUnaryFunctions", () => {
                 getNextPageParam: (lastPage) => lastPage.page + 1n,
                 transport,
                 callOptions: mockCallOptions,
-              },
-            ),
+              }
+            )
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       expect(transportSpy).toHaveBeenCalledWith(
@@ -601,7 +603,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.headers, // headers
         expect.objectContaining({
           page: 1n,
-        }), // input
+        }) // input
       );
     });
 
@@ -624,10 +626,10 @@ describe("createUnaryFunctions", () => {
                   // @ts-expect-error(2345) ignore these errors for testing
                   ...input,
                 }),
-              },
-            ),
+              }
+            )
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
     });
 
@@ -642,9 +644,9 @@ describe("createUnaryFunctions", () => {
               getNextPageParam: (lastPage) => lastPage.page + 1n,
               transport,
               callOptions: mockCallOptions,
-            },
+            }
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       expect(result.current.queryKey).toStrictEqual([
@@ -679,9 +681,9 @@ describe("createUnaryFunctions", () => {
               getNextPageParam: (lastPage) => lastPage.page + 1n,
               transport,
               callOptions: mockCallOptions,
-            },
+            }
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       expect(result.current.queryKey).toStrictEqual([
@@ -717,10 +719,10 @@ describe("createUnaryFunctions", () => {
                 getNextPageParam: (lastPage) => lastPage.page + 1n,
                 transport,
                 callOptions: mockCallOptions,
-              },
-            ),
+              }
+            )
           ),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       expect(transportSpy).toHaveBeenCalledWith(
@@ -731,7 +733,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.headers, // headers
         expect.objectContaining({
           page: 2n,
-        }), // input
+        }) // input
       );
     });
   });
@@ -754,9 +756,9 @@ describe("createUnaryFunctions", () => {
           useMutation(
             customSay.createUseMutationOptions({
               transport: mockTransportOption,
-            }),
+            })
           ),
-        wrapper({}, mockTransportContext),
+        wrapper({}, mockTransportContext)
       );
 
       result.current.mutate({});
@@ -773,7 +775,9 @@ describe("createUnaryFunctions", () => {
     it("requires a transport", () => {
       expect(() => {
         genCount.createUseMutationOptions();
-      }).toThrow("Transport must be provided");
+      }).toThrow(
+        "Invalid assertion: createUseMutationOptions requires you to provide a Transport."
+      );
     });
 
     it("has the intended API surface", () => {
@@ -803,7 +807,7 @@ describe("createUnaryFunctions", () => {
               input: PartialMessage<CountRequest>,
               context?:
                 | QueryFunctionContext<ConnectQueryKey<CountRequest>>
-                | undefined,
+                | undefined
             ) => Promise<CountResponse>;
             onError?: (error: ConnectError) => void;
           }
@@ -815,11 +819,11 @@ describe("createUnaryFunctions", () => {
           genCount.createUseMutationOptions({
             transport: mockBigInt(),
           }),
-        wrapper(),
+        wrapper()
       );
 
       expect(
-        Object.keys(result.current).sort((a, b) => a.localeCompare(b)),
+        Object.keys(result.current).sort((a, b) => a.localeCompare(b))
       ).toStrictEqual(["mutationFn"]);
     });
 
@@ -837,7 +841,7 @@ describe("createUnaryFunctions", () => {
             mutationFn: async () => Promise.reject("error"),
             mutationKey: genCount.getQueryKey(),
           }),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       rerender();
@@ -867,7 +871,7 @@ describe("createUnaryFunctions", () => {
 
       const { queryClient, transport, ...rest } = wrapper(
         { defaultOptions },
-        mockStatefulBigIntTransport(),
+        mockStatefulBigIntTransport()
       );
       const { result } = renderHook(
         () => ({
@@ -882,17 +886,17 @@ describe("createUnaryFunctions", () => {
                 queryClient.getQueryData<CountResponse>(queryKey) ?? {};
 
               queryClient.setQueryData(
-                ...genCount.setQueryData({ count: count + input.add }, input),
+                ...genCount.setQueryData({ count: count + input.add }, input)
               );
             },
           }),
           get: useQuery(
             genCount.createUseQueryOptions(input, {
               transport,
-            }),
+            })
           ),
         }),
-        rest,
+        rest
       );
 
       type ExpectType_MutationFn = Expect<
@@ -939,7 +943,7 @@ describe("createUnaryFunctions", () => {
             }),
             mutationKey: genCount.getQueryKey({ add: 1n }),
           }),
-        wrapper({ defaultOptions }),
+        wrapper({ defaultOptions })
       );
 
       result.current.mutate({ add: 2n });
@@ -954,7 +958,7 @@ describe("createUnaryFunctions", () => {
         mockCallOptions.signal, // signal
         mockCallOptions.timeoutMs, // timeoutMs
         mockCallOptions.headers, // headers
-        expect.anything(), // input
+        expect.anything() // input
       );
     });
   });
@@ -974,7 +978,7 @@ describe("createUnaryFunctions", () => {
           params[1],
           | {
               getPlaceholderData?: (
-                enabled: boolean,
+                enabled: boolean
               ) => PartialMessage<SayResponse> | undefined;
               onError?: (error: ConnectError) => void;
               transport?: Transport | undefined;
@@ -995,7 +999,7 @@ describe("createUnaryFunctions", () => {
             enabled: boolean;
             queryKey: ConnectQueryKey<SayRequest>;
             queryFn: (
-              context?: QueryFunctionContext<ConnectQueryKey<SayRequest>>,
+              context?: QueryFunctionContext<ConnectQueryKey<SayRequest>>
             ) => Promise<SayResponse>;
             placeholderData?: () => SayResponse | undefined;
             onError?: (error: ConnectError) => void;
@@ -1010,7 +1014,7 @@ describe("createUnaryFunctions", () => {
       });
 
       expect(
-        Object.keys(result).sort((a, b) => a.localeCompare(b)),
+        Object.keys(result).sort((a, b) => a.localeCompare(b))
       ).toStrictEqual([
         "enabled",
         "onError",
@@ -1027,7 +1031,7 @@ describe("createUnaryFunctions", () => {
           {},
           {
             transport: mockEliza(),
-          },
+          }
         );
         type ExpectType_Expect = Expect<Equal<typeof result.enabled, boolean>>;
       });
@@ -1037,7 +1041,7 @@ describe("createUnaryFunctions", () => {
           {},
           {
             transport: mockEliza(),
-          },
+          }
         );
 
         expect(result).toHaveProperty("enabled", true);
@@ -1110,7 +1114,7 @@ describe("createUnaryFunctions", () => {
       it("will use pass the value of `enabled` to the getPlaceholderData callback", () => {
         const getPlaceholderData = jest.fn<
           (
-            enabled?: boolean | undefined,
+            enabled?: boolean | undefined
           ) => PartialMessage<SayResponse> | undefined
         >(() => ({}));
         const { result } = renderHook(
@@ -1119,9 +1123,9 @@ describe("createUnaryFunctions", () => {
               genSay.createUseQueryOptions(disableQuery, {
                 getPlaceholderData,
                 transport: mockEliza(),
-              }),
+              })
             ),
-          wrapper(),
+          wrapper()
         );
 
         expect(result.current.data?.sentence).toStrictEqual("");
@@ -1131,7 +1135,7 @@ describe("createUnaryFunctions", () => {
       it("will be undefined if getPlaceholderData returns undefined", () => {
         const getPlaceholderData = jest.fn<
           (
-            enabled?: boolean | undefined,
+            enabled?: boolean | undefined
           ) => PartialMessage<SayResponse> | undefined
         >(() => undefined);
         const { result } = renderHook(
@@ -1140,9 +1144,9 @@ describe("createUnaryFunctions", () => {
               genSay.createUseQueryOptions(disableQuery, {
                 getPlaceholderData,
                 transport: mockEliza(),
-              }),
+              })
             ),
-          wrapper(),
+          wrapper()
         );
 
         expect(result.current.data?.sentence).toStrictEqual(undefined);
@@ -1173,12 +1177,12 @@ describe("createUnaryFunctions", () => {
               ...genSay.createUseQueryOptions(
                 // @ts-expect-error(2345) intentionally invalid input
                 { nope: "nope nope" },
-                { onError, transport: mockEliza() },
+                { onError, transport: mockEliza() }
               ),
               queryFn: async () => Promise.reject("error"),
               retry: false,
             }),
-          wrapper(),
+          wrapper()
         );
         rerender();
 
@@ -1210,7 +1214,7 @@ describe("createUnaryFunctions", () => {
             (
               context?:
                 | QueryFunctionContext<ConnectQueryKey<SayRequest>>
-                | undefined,
+                | undefined
             ) => Promise<SayResponse>
           >
         >;
@@ -1231,8 +1235,8 @@ describe("createUnaryFunctions", () => {
 
         await expect(result.queryFn).rejects.toStrictEqual(
           new Error(
-            "Invalid assertion: queryFn does not accept a disabled query",
-          ),
+            "Invalid assertion: queryFn does not accept a disabled query"
+          )
         );
       });
 
@@ -1247,10 +1251,10 @@ describe("createUnaryFunctions", () => {
                 {
                   transport,
                   callOptions: mockCallOptions,
-                },
-              ),
+                }
+              )
             ),
-          wrapper(),
+          wrapper()
         );
 
         expect(transportSpy).toHaveBeenCalledWith(
@@ -1259,7 +1263,7 @@ describe("createUnaryFunctions", () => {
           mockCallOptions.signal, // signal
           mockCallOptions.timeoutMs, // timeoutMs
           mockCallOptions.headers, // headers
-          expect.anything(), // input
+          expect.anything() // input
         );
       });
     });

--- a/packages/connect-query/src/create-unary-functions.ts
+++ b/packages/connect-query/src/create-unary-functions.ts
@@ -72,7 +72,7 @@ export interface UnaryFunctions<I extends Message<I>, O extends Message<O>> {
   /**
    * createUseQueryOptions is intended to be used with `useQuery`, but is not a hook.  Since hooks cannot be called conditionally (or in loops), it can sometimes be helpful to use `createUseQueryOptions` to prepare an input to TanStack's `useQuery` API.
    *
-   * The caveat being that if you go the route of using `createUseQueryOptions` you must provide transport.  You can get transport from the `useTransport` export.  If you cannot use hooks to retrieve transport, then look at the documentation for `TransportProvider` to learn more about how to use Connect-Web's createConnectTransport` or `createGrpcWebTransport`APIs.
+   * The caveat being that if you go the route of using `createUseQueryOptions` you must provide transport.  You can get transport from the `useTransport` export, or make sure these functions were generated with createQueryService() with a transport provided.
    */
   createUseQueryOptions: (
     input?: DisableQuery | PartialMessage<I> | undefined,
@@ -199,7 +199,7 @@ export const createUnaryFunctions = <
 
     assert(
       transport !== undefined,
-      "createUseQueryOptions requires you to provide a Transport.  If you want automatic inference of Transport, try using the useQuery helper.",
+      "createUseQueryOptions requires you to provide a Transport.",
     );
 
     return {
@@ -270,9 +270,10 @@ export const createUnaryFunctions = <
     ) => {
       const transport = optionsTransport ?? topLevelCustomTransport;
 
-      if (transport === undefined) {
-        throw new Error("Transport must be provided");
-      }
+      assert(
+        transport !== undefined,
+        "createUseInfiniteQueryOptions requires you to provide a Transport.",
+      );
 
       const enabled = input !== disableQuery;
       let sanitizedInput = input;
@@ -340,9 +341,10 @@ export const createUnaryFunctions = <
     } = {}) => {
       const transport = optionsTransport ?? topLevelCustomTransport;
 
-      if (transport === undefined) {
-        throw new Error("Transport must be provided");
-      }
+      assert(
+        transport !== undefined,
+        "createUseMutationOptions requires you to provide a Transport.",
+      );
 
       return {
         mutationFn: async (input, context) => {

--- a/packages/connect-query/src/create-unary-functions.ts
+++ b/packages/connect-query/src/create-unary-functions.ts
@@ -64,7 +64,7 @@ interface BaseInfiniteQueryOptions<
 /**
  * The set of data and hooks that a unary method supports.
  */
-export interface UnaryHooks<I extends Message<I>, O extends Message<O>> {
+export interface UnaryFunctions<I extends Message<I>, O extends Message<O>> {
   /**
    * Use this to create a data object that can be used as `placeholderData` or `initialData`.
    */
@@ -188,7 +188,10 @@ export interface UnaryHooks<I extends Message<I>, O extends Message<O>> {
 /**
  * A helper function that will configure the set of hooks a Unary method supports.
  */
-export const unaryHooks = <I extends Message<I>, O extends Message<O>>({
+export const createUnaryFunctions = <
+  I extends Message<I>,
+  O extends Message<O>,
+>({
   methodInfo,
   typeName,
   transport: topLevelCustomTransport,
@@ -196,11 +199,11 @@ export const unaryHooks = <I extends Message<I>, O extends Message<O>>({
   methodInfo: MethodInfoUnary<I, O>;
   typeName: ServiceType["typeName"];
   transport?: Transport | undefined;
-}): UnaryHooks<I, O> => {
+}): UnaryFunctions<I, O> => {
   if (!isUnaryMethod(methodInfo)) {
     throw unreachableCase(
       methodInfo,
-      `unaryHooks was passed a non unary method, ${
+      `createUnaryFunctions was passed a non unary method, ${
         (methodInfo as { name: string }).name
       }`,
     );
@@ -208,7 +211,7 @@ export const unaryHooks = <I extends Message<I>, O extends Message<O>>({
 
   const getQueryKey = makeConnectQueryKeyGetter(typeName, methodInfo.name);
 
-  const createUseQueryOptions: UnaryHooks<I, O>["createUseQueryOptions"] = (
+  const createUseQueryOptions: UnaryFunctions<I, O>["createUseQueryOptions"] = (
     input,
     { callOptions, getPlaceholderData, onError, transport },
   ) => {

--- a/packages/connect-query/src/create-unary-hooks.ts
+++ b/packages/connect-query/src/create-unary-hooks.ts
@@ -36,8 +36,8 @@ export interface UnaryHooks<
 /**
  * Creates the hooks for a given set of unary methods.
  */
-export function createHooks<I extends Message<I>, O extends Message<O>>(
-  unaryMethods: UnaryFunctions<I, O>,
+export function createUnaryHooks<I extends Message<I>, O extends Message<O>>(
+  unaryMethods: UnaryFunctions<I, O>
 ): UnaryHooks<I, O, UnaryFunctions<I, O>> {
   return {
     useQuery: (input, options) => {

--- a/packages/connect-query/src/create-unary-hooks.ts
+++ b/packages/connect-query/src/create-unary-hooks.ts
@@ -37,7 +37,7 @@ export interface UnaryHooks<
  * Creates the hooks for a given set of unary methods.
  */
 export function createUnaryHooks<I extends Message<I>, O extends Message<O>>(
-  unaryMethods: UnaryFunctions<I, O>
+  unaryMethods: UnaryFunctions<I, O>,
 ): UnaryHooks<I, O, UnaryFunctions<I, O>> {
   return {
     useQuery: (input, options) => {

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -20,7 +20,7 @@ export type {
   SupportedMethodKinds,
 } from "./create-query-functions";
 export {
-  createQueryFunctions as createQueryHooks,
+  createQueryFunctions,
   supportedMethodKinds,
   isSupportedMethod,
 } from "./create-query-functions";

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -14,7 +14,7 @@
 
 export { createQueryService } from "./create-query-service";
 export type {
-  QueryFunctions as QueryHooks,
+  QueryFunctions,
   SupportedMethodInfo,
   IsSupportedMethod,
   SupportedMethodKinds,

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -14,21 +14,21 @@
 
 export { createQueryService } from "./create-query-service";
 export type {
-  QueryHooks,
+  QueryFunctions as QueryHooks,
   SupportedMethodInfo,
   IsSupportedMethod,
   SupportedMethodKinds,
-} from "./create-query-hooks";
+} from "./create-query-functions";
 export {
-  createQueryHooks,
+  createQueryFunctions as createQueryHooks,
   supportedMethodKinds,
   isSupportedMethod,
-} from "./create-query-hooks";
+} from "./create-query-functions";
 export type {
   ConnectQueryKey,
   ConnectPartialQueryKey,
 } from "./connect-query-key";
-export type { UnaryHooks } from "./unary-hooks";
-export { unaryHooks } from "./unary-hooks";
+export type { UnaryFunctions } from "./create-unary-functions";
+export { createUnaryFunctions } from "./create-unary-functions";
 export { disableQuery } from "./utils";
 export { useTransport, TransportProvider } from "./use-transport";

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -14,8 +14,8 @@
 
 import type { Message } from "@bufbuild/protobuf";
 
-import type { UnaryHooks } from "./create-hooks";
 import type { UnaryFunctions } from "./create-unary-functions";
+import type { UnaryHooks } from "./create-unary-hooks";
 
 export { createQueryService } from "./create-query-service";
 export type {
@@ -37,8 +37,8 @@ export type { UnaryFunctions } from "./create-unary-functions";
 export { createUnaryFunctions } from "./create-unary-functions";
 export { disableQuery } from "./utils";
 export { useTransport, TransportProvider } from "./use-transport";
-export type { UnaryHooks } from "./create-hooks";
-export { createHooks } from "./create-hooks";
+export type { UnaryHooks } from "./create-unary-hooks";
+export { createUnaryHooks } from "./create-unary-hooks";
 
 /**
  * Combined type of all the functions generated for a service.

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import type { Message } from "@bufbuild/protobuf";
+
+import type { UnaryHooks } from "./create-hooks";
+import type { UnaryFunctions } from "./create-unary-functions";
+
 export { createQueryService } from "./create-query-service";
 export type {
   QueryFunctions,
@@ -32,3 +37,13 @@ export type { UnaryFunctions } from "./create-unary-functions";
 export { createUnaryFunctions } from "./create-unary-functions";
 export { disableQuery } from "./utils";
 export { useTransport, TransportProvider } from "./use-transport";
+export type { UnaryHooks } from "./create-hooks";
+export { createHooks } from "./create-hooks";
+
+/**
+ * Combined type of all the functions generated for a service.
+ */
+export type UnaryFunctionsWithHooks<
+  I extends Message<I>,
+  O extends Message<O>,
+> = UnaryFunctions<I, O> & UnaryHooks<I, O, UnaryFunctions<I, O>>;

--- a/packages/connect-query/src/jest/test-utils.tsx
+++ b/packages/connect-query/src/jest/test-utils.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { PartialMessage } from "@bufbuild/protobuf";
-import type { CallOptions } from "@connectrpc/connect";
+import type { CallOptions, Transport } from "@connectrpc/connect";
 import { createRouterTransport } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
 import type { QueryClientConfig } from "@tanstack/react-query";
@@ -40,6 +40,7 @@ export const wrapper = (
 ): {
   wrapper: JSXElementConstructor<PropsWithChildren>;
   queryClient: QueryClient;
+  transport: Transport;
 } => {
   const queryClient = new QueryClient(config);
   return {
@@ -51,6 +52,7 @@ export const wrapper = (
       </TransportProvider>
     ),
     queryClient,
+    transport,
   };
 };
 

--- a/packages/connect-query/src/use-transport.test.tsx
+++ b/packages/connect-query/src/use-transport.test.tsx
@@ -18,29 +18,29 @@ import { useQuery } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { spyOn } from "jest-mock";
 
+import { createUnaryFunctions } from "./create-unary-functions";
 import { ElizaService } from "./gen/eliza_connect";
 import { sleep, wrapper } from "./jest/test-utils";
-import { unaryHooks } from "./unary-hooks";
 import { fallbackTransport } from "./use-transport";
 
 const error = new ConnectError(
-  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info.",
+  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info."
 );
 
 describe("fallbackTransport", () => {
   it("throws a helpful error message", async () => {
     await expect(Promise.reject(fallbackTransport.unary)).rejects.toThrow(
-      error,
+      error
     );
     await expect(Promise.reject(fallbackTransport.stream)).rejects.toThrow(
-      error,
+      error
     );
   });
 });
 
 describe("useTransport", () => {
   const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
-  const say = unaryHooks({
+  const say = createUnaryFunctions({
     methodInfo: ElizaService.methods.say,
     typeName: ElizaService.typeName,
   });
@@ -48,7 +48,7 @@ describe("useTransport", () => {
   it("throws the fallback error", async () => {
     const { result, rerender } = renderHook(
       () => useQuery({ ...say.useQuery(), retry: false }),
-      wrapper({}, fallbackTransport),
+      wrapper({}, fallbackTransport)
     );
     rerender();
 

--- a/packages/connect-query/src/use-transport.test.tsx
+++ b/packages/connect-query/src/use-transport.test.tsx
@@ -20,20 +20,24 @@ import { spyOn } from "jest-mock";
 
 import { createUnaryFunctions } from "./create-unary-functions";
 import { ElizaService } from "./gen/eliza_connect";
-import { sleep, wrapper } from "./jest/test-utils";
-import { fallbackTransport } from "./use-transport";
+import { mockBigInt, sleep, wrapper } from "./jest/test-utils";
+import {
+  fallbackTransport,
+  TransportProvider,
+  useTransport,
+} from "./use-transport";
 
 const error = new ConnectError(
-  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info."
+  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info.",
 );
 
 describe("fallbackTransport", () => {
   it("throws a helpful error message", async () => {
     await expect(Promise.reject(fallbackTransport.unary)).rejects.toThrow(
-      error
+      error,
     );
     await expect(Promise.reject(fallbackTransport.stream)).rejects.toThrow(
-      error
+      error,
     );
   });
 });
@@ -47,8 +51,14 @@ describe("useTransport", () => {
 
   it("throws the fallback error", async () => {
     const { result, rerender } = renderHook(
-      () => useQuery({ ...say.useQuery(), retry: false }),
-      wrapper({}, fallbackTransport)
+      () =>
+        useQuery({
+          ...say.createUseQueryOptions(undefined, {
+            transport: fallbackTransport,
+          }),
+          retry: false,
+        }),
+      wrapper(),
     );
     rerender();
 
@@ -61,5 +71,17 @@ describe("useTransport", () => {
     expect(result.current.error).toEqual(error);
     expect(result.current.isError).toStrictEqual(true);
     expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+  });
+});
+
+describe("TransportProvider", () => {
+  it("provides a custom transport to the useTransport hook", () => {
+    const transport = mockBigInt();
+    const { result } = renderHook(() => useTransport(), {
+      wrapper: ({ children }) => (
+        <TransportProvider transport={transport}>{children}</TransportProvider>
+      ),
+    });
+    expect(result.current).toBe(transport);
   });
 });

--- a/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.d.ts
+++ b/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.d.ts
@@ -26,7 +26,7 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind, PartialMessage } from "@bufbuild/protobuf";
-import { ConnectQueryKey, UnaryHooks } from "@connectrpc/connect-query";
+import { ConnectQueryKey, UnaryFunctions } from "@connectrpc/connect-query";
 import {
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
@@ -89,10 +89,10 @@ export declare const ElizaService: {
   };
 };
 
-export const say: UnaryHooks<SayRequest, SayResponse>;
+export const say: UnaryFunctions<SayRequest, SayResponse>;
 export declare const useSayQuery: (
-  inputs: Parameters<typeof say.useQuery>[0],
-  options?: Parameters<typeof say.useQuery>[1],
+  input: Parameters<typeof say.createUseQueryOptions>[0],
+  options?: Parameters<typeof say.createUseQueryOptions>[1],
   queryOptions?: Partial<
     UseQueryOptions<
       SayResponse,
@@ -104,13 +104,9 @@ export declare const useSayQuery: (
 ) => UseQueryResult<SayResponse, ConnectError>;
 
 export declare const useSayMutation: (
-  options?: Parameters<typeof say.useMutation>[0],
+  options?: Parameters<typeof say.createUseMutationOptions>[0],
   queryOptions?: Partial<
-    UseMutationOptions<
-      PartialMessage<SayResponse>,
-      ConnectError,
-      PartialMessage<SayRequest>
-    >
+    UseMutationOptions<SayResponse, ConnectError, PartialMessage<SayRequest>>
   >,
 ) => UseMutationResult<
   SayResponse,
@@ -120,8 +116,8 @@ export declare const useSayMutation: (
 >;
 
 export declare const useSayInfiniteQuery: (
-  inputs: Parameters<typeof say.useInfiniteQuery>[0],
-  options: Parameters<typeof say.useInfiniteQuery>[1],
+  input: Parameters<typeof say.createUseInfiniteQueryOptions>[0],
+  options: Parameters<typeof say.createUseInfiniteQueryOptions>[1],
   queryOptions?: Partial<
     UseInfiniteQueryOptions<
       SayResponse,

--- a/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.ts
+++ b/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.ts
@@ -26,7 +26,11 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind, PartialMessage } from "@bufbuild/protobuf";
-import { ConnectQueryKey, createQueryService } from "@connectrpc/connect-query";
+import {
+  ConnectQueryKey,
+  createHooks,
+  createQueryService,
+} from "@connectrpc/connect-query";
 import {
   useInfiniteQuery,
   UseInfiniteQueryOptions,
@@ -89,17 +93,18 @@ export const ElizaService = {
   },
 } as const;
 
+const queryService = createQueryService({
+  service: ElizaService,
+});
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = createQueryService({
-  service: ElizaService,
-}).say;
+export const say = createHooks(queryService.say);
 
 export const useSayQuery = (
-  inputs: Parameters<typeof say.useQuery>[0],
+  input?: Parameters<typeof say.useQuery>[0],
   options?: Parameters<typeof say.useQuery>[1],
   queryOptions?: Partial<
     UseQueryOptions<
@@ -110,7 +115,7 @@ export const useSayQuery = (
     >
   >,
 ) => {
-  const baseOptions = say.useQuery(inputs, options);
+  const baseOptions = say.useQuery(input, options);
 
   return useQuery({
     ...baseOptions,
@@ -121,11 +126,7 @@ export const useSayQuery = (
 export const useSayMutation = (
   options?: Parameters<typeof say.useMutation>[0],
   queryOptions?: Partial<
-    UseMutationOptions<
-      PartialMessage<SayResponse>,
-      ConnectError,
-      PartialMessage<SayRequest>
-    >
+    UseMutationOptions<SayResponse, ConnectError, PartialMessage<SayRequest>>
   >,
 ) => {
   const baseOptions = say.useMutation(options);
@@ -137,7 +138,7 @@ export const useSayMutation = (
 };
 
 export const useSayInfiniteQuery = (
-  inputs: Parameters<typeof say.useInfiniteQuery>[0],
+  input: Parameters<typeof say.useInfiniteQuery>[0],
   options: Parameters<typeof say.useInfiniteQuery>[1],
   queryOptions?: Partial<
     UseInfiniteQueryOptions<
@@ -149,13 +150,13 @@ export const useSayInfiniteQuery = (
     >
   >,
 ) => {
-  const baseOptions = say.useInfiniteQuery(inputs, options);
+  const baseOptions = say.useInfiniteQuery(input, options);
 
   return useInfiniteQuery<
     SayResponse,
     ConnectError,
     SayResponse,
-    keyof typeof inputs extends never ? any : ConnectQueryKey<SayRequest>
+    keyof typeof input extends never ? any : ConnectQueryKey<SayRequest>
   >({
     ...baseOptions,
     ...queryOptions,

--- a/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.ts
+++ b/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.ts
@@ -93,7 +93,7 @@ export const ElizaService = {
   },
 } as const;
 
-const queryService = createQueryService({
+const $queryService = createQueryService({
   service: ElizaService,
 });
 /**
@@ -101,7 +101,7 @@ const queryService = createQueryService({
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = createUnaryHooks(queryService.say);
+export const say = createUnaryHooks($queryService.say);
 
 export const useSayQuery = (
   input?: Parameters<typeof say.useQuery>[0],

--- a/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.ts
+++ b/packages/protoc-gen-connect-query-react/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery_react.ts
@@ -28,8 +28,8 @@ import {
 import { MethodKind, PartialMessage } from "@bufbuild/protobuf";
 import {
   ConnectQueryKey,
-  createHooks,
   createQueryService,
+  createUnaryHooks,
 } from "@connectrpc/connect-query";
 import {
   useInfiniteQuery,
@@ -101,7 +101,7 @@ const queryService = createQueryService({
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = createHooks(queryService.say);
+export const say = createUnaryHooks(queryService.say);
 
 export const useSayQuery = (
   input?: Parameters<typeof say.useQuery>[0],

--- a/packages/protoc-gen-connect-query-react/src/generateDts.ts
+++ b/packages/protoc-gen-connect-query-react/src/generateDts.ts
@@ -94,8 +94,8 @@ const generateServiceFile =
             );
 
             f.print(`export declare const `, reactHookName(method, 'Query'), ': (');
-            f.print(`    inputs: Parameters<typeof `,serviceName, `.useQuery>[0],`);
-            f.print(`    options?: Parameters<typeof `, serviceName, `.useQuery>[1],`,);
+            f.print(`    input: Parameters<typeof `,serviceName, `.createUseQueryOptions>[0],`);
+            f.print(`    options?: Parameters<typeof `, serviceName, `.createUseQueryOptions>[1],`,);
             f.print(`    queryOptions?: Partial<`, useQueryOptions, `<`,  method.output, `, `, connectError, `, `, method.output, `, `, connectQueryKey, `<`, method.input, `>>>`);
 
             f.print(`) => `, useQueryResult, `<`, method.output, `,`, connectError, `>;`);
@@ -112,8 +112,8 @@ const generateServiceFile =
             );
 
             f.print(`export declare const `, reactHookName(method, 'Mutation'), ': (');
-            f.print(`    options?: Parameters<typeof `, serviceName, `.useMutation>[0],`);
-            f.print(`    queryOptions?: Partial<`, useMutationOptions, `<`, partialMessage, `<`, method.output, `>, `, connectError, `, `, partialMessage, `<`, method.input, `>>>`);
+            f.print(`    options?: Parameters<typeof `, serviceName, `.createUseMutationOptions>[0],`);
+            f.print(`    queryOptions?: Partial<`, useMutationOptions, `<`, method.output, `, `, connectError, `, `, partialMessage, `<`, method.input, `>>>`);
             f.print(`) => `, useMutationResult, `<`, method.output, `,`, connectError, ',', partialMessage, `<`, method.input, '>',`, unknown>;`);
             f.print(``);
 
@@ -128,8 +128,8 @@ const generateServiceFile =
             );
 
             f.print(`export declare const `, reactHookName(method, 'InfiniteQuery'), ': (');
-            f.print(`    inputs: Parameters<typeof `, serviceName, `.useInfiniteQuery>[0],`);
-            f.print(`    options: Parameters<typeof `, serviceName, `.useInfiniteQuery>[1],`);
+            f.print(`    input: Parameters<typeof `, serviceName, `.createUseInfiniteQueryOptions>[0],`);
+            f.print(`    options: Parameters<typeof `, serviceName, `.createUseInfiniteQueryOptions>[1],`);
             f.print(`    queryOptions?: Partial<`, useInfiniteQueryOptions, `<`, method.output, `, `, connectError, `, `, method.output, `, `, method.output, `, `, connectQueryKey, `<`, method.input, `>>>`);
             f.print(`) => `, useInfiniteQueryResult, `<`, method.output, `,`, connectError, `>;`);
             f.print(``);

--- a/packages/protoc-gen-connect-query-react/src/generateDts.ts
+++ b/packages/protoc-gen-connect-query-react/src/generateDts.ts
@@ -75,7 +75,7 @@ const generateServiceFile =
               `export const `,
               serviceName,
               `: `,
-              f.import('UnaryHooks', '@connectrpc/connect-query'),
+              f.import('UnaryFunctions', '@connectrpc/connect-query'),
               `<`,
               method.input,
               `, `,

--- a/packages/protoc-gen-connect-query-react/src/generateTs.ts
+++ b/packages/protoc-gen-connect-query-react/src/generateTs.ts
@@ -68,7 +68,7 @@ const generateServiceFile =
     f.print();
 
     f.print(
-      `const queryService = `,
+      `const $queryService = `,
       f.import('createQueryService', '@connectrpc/connect-query'),
       `({`,
     );
@@ -88,7 +88,7 @@ const generateServiceFile =
         f.print(makeJsDoc(method));
 
         f.print(
-          `export const ${methodName} = `, createUnaryHooks, `(queryService.${localName(method)});`); // Note, the reason for dot accessing the method rather than destructuring at the top is that it allows for a TSDoc to be attached to the exported variable.  Also it's nice that each method has its own atomic section that you could independently inspect and debug (i.e. commenting a single method is much easier when it's one contiguous set of lines).
+          `export const ${methodName} = `, createUnaryHooks, `($queryService.${localName(method)});`); // Note, the reason for dot accessing the method rather than destructuring at the top is that it allows for a TSDoc to be attached to the exported variable.  Also it's nice that each method has its own atomic section that you could independently inspect and debug (i.e. commenting a single method is much easier when it's one contiguous set of lines).
         f.print(``);
 
         // useQuery

--- a/packages/protoc-gen-connect-query-react/src/generateTs.ts
+++ b/packages/protoc-gen-connect-query-react/src/generateTs.ts
@@ -83,12 +83,12 @@ const generateServiceFile =
         const partialMessage = f.import('PartialMessage', '@bufbuild/protobuf');
         const connectError = f.import('ConnectError', '@connectrpc/connect');
         const connectQueryKey = f.import("ConnectQueryKey", "@connectrpc/connect-query");
-        const createHooks = f.import('createHooks', '@connectrpc/connect-query');
+        const createUnaryHooks = f.import('createUnaryHooks', '@connectrpc/connect-query');
 
         f.print(makeJsDoc(method));
 
         f.print(
-          `export const ${methodName} = `, createHooks, `(queryService.${localName(method)});`); // Note, the reason for dot accessing the method rather than destructuring at the top is that it allows for a TSDoc to be attached to the exported variable.  Also it's nice that each method has its own atomic section that you could independently inspect and debug (i.e. commenting a single method is much easier when it's one contiguous set of lines).
+          `export const ${methodName} = `, createUnaryHooks, `(queryService.${localName(method)});`); // Note, the reason for dot accessing the method rather than destructuring at the top is that it allows for a TSDoc to be attached to the exported variable.  Also it's nice that each method has its own atomic section that you could independently inspect and debug (i.e. commenting a single method is much easier when it's one contiguous set of lines).
         f.print(``);
 
         // useQuery

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.d.ts
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.d.ts
@@ -26,7 +26,7 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { UnaryHooks } from "@connectrpc/connect-query";
+import { UnaryFunctionsWithHooks } from "@connectrpc/connect-query";
 
 /**
  * ElizaService provides a way to talk to Eliza, a port of the DOCTOR script
@@ -80,4 +80,4 @@ export declare const ElizaService: {
   };
 };
 
-export const say: UnaryHooks<SayRequest, SayResponse>;
+export const say: UnaryFunctionsWithHooks<SayRequest, SayResponse>;

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.js
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.js
@@ -85,7 +85,7 @@ export const ElizaService = {
   },
 };
 
-const queryService = createQueryService({ service: ElizaService });
+const $queryService = createQueryService({ service: ElizaService });
 
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
@@ -93,6 +93,6 @@ const queryService = createQueryService({ service: ElizaService });
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
 export const say = {
-  ...queryService.say,
-  ...createUnaryHooks(queryService.say),
+  ...$queryService.say,
+  ...createUnaryHooks($queryService.say),
 };

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.js
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.js
@@ -26,7 +26,7 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.ElizaService";
 
@@ -82,11 +82,11 @@ export const ElizaService = {
   },
 };
 
+const queryService = createQueryService({ service: ElizaService });
+
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = createQueryService({
-  service: ElizaService,
-}).say;
+export const say = { ...queryService.say, ...createHooks(queryService.say) };

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.js
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.js
@@ -26,7 +26,10 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.ElizaService";
 
@@ -89,4 +92,7 @@ const queryService = createQueryService({ service: ElizaService });
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = { ...queryService.say, ...createHooks(queryService.say) };
+export const say = {
+  ...queryService.say,
+  ...createUnaryHooks(queryService.say),
+};

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.ts
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.ts
@@ -26,7 +26,7 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createQueryService } from "@connectrpc/connect-query";
+import { createHooks, createQueryService } from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.ElizaService";
 
@@ -82,11 +82,11 @@ export const ElizaService = {
   },
 } as const;
 
+const queryService = createQueryService({ service: ElizaService });
+
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = createQueryService({
-  service: ElizaService,
-}).say;
+export const say = { ...queryService.say, ...createHooks(queryService.say) };

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.ts
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.ts
@@ -85,7 +85,7 @@ export const ElizaService = {
   },
 } as const;
 
-const queryService = createQueryService({ service: ElizaService });
+const $queryService = createQueryService({ service: ElizaService });
 
 /**
  * Say is a unary RPC. Eliza responds to the prompt with a single sentence.
@@ -93,6 +93,6 @@ const queryService = createQueryService({ service: ElizaService });
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
 export const say = {
-  ...queryService.say,
-  ...createUnaryHooks(queryService.say),
+  ...$queryService.say,
+  ...createUnaryHooks($queryService.say),
 };

--- a/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.ts
+++ b/packages/protoc-gen-connect-query/snapshots/gen/connectrpc/eliza/v1/eliza-ElizaService_connectquery.ts
@@ -26,7 +26,10 @@ import {
   SayResponse,
 } from "./eliza_pb";
 import { MethodKind } from "@bufbuild/protobuf";
-import { createHooks, createQueryService } from "@connectrpc/connect-query";
+import {
+  createQueryService,
+  createUnaryHooks,
+} from "@connectrpc/connect-query";
 
 export const typeName = "connectrpc.eliza.v1.ElizaService";
 
@@ -89,4 +92,7 @@ const queryService = createQueryService({ service: ElizaService });
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say = { ...queryService.say, ...createHooks(queryService.say) };
+export const say = {
+  ...queryService.say,
+  ...createUnaryHooks(queryService.say),
+};

--- a/packages/protoc-gen-connect-query/src/generateDts.ts
+++ b/packages/protoc-gen-connect-query/src/generateDts.ts
@@ -60,6 +60,8 @@ const generateServiceFile =
     f.print("};");
     f.print();
 
+    const unaryFunctionsWithHooks = f.import('UnaryFunctionsWithHooks', '@connectrpc/connect-query');
+
     service.methods.forEach((method) => {
       switch (method.methodKind) {
         case MethodKind.Unary:
@@ -68,12 +70,13 @@ const generateServiceFile =
               `export const `,
               safeIdentifier(localName(method)),
               `: `,
-              f.import('UnaryHooks', '@connectrpc/connect-query'),
+              unaryFunctionsWithHooks,
               `<`,
-              method.input,
-              `, `,
-              method.output,
-              `>;`,
+                method.input,
+                `, `,
+                method.output,
+              `>`,
+              ';'
             );
           }
           break;

--- a/packages/protoc-gen-connect-query/src/generateTs.ts
+++ b/packages/protoc-gen-connect-query/src/generateTs.ts
@@ -82,7 +82,7 @@ const generateServiceFile =
         f.print(
           `export const ${safeIdentifier(localName(method))} = { `,
           `  ...queryService.${localName(method)},`,
-          `  ...`, f.import('createHooks', '@connectrpc/connect-query'),`(queryService.${localName(method)})`,
+          `  ...`, f.import('createUnaryHooks', '@connectrpc/connect-query'),`(queryService.${localName(method)})`,
           `};`
         );
 

--- a/packages/protoc-gen-connect-query/src/generateTs.ts
+++ b/packages/protoc-gen-connect-query/src/generateTs.ts
@@ -66,7 +66,7 @@ const generateServiceFile =
     f.print("}", extension === "ts" ? " as const" : "", ";");
     f.print();
 
-    f.print(`const queryService = `,
+    f.print(`const $queryService = `,
       f.import('createQueryService', '@connectrpc/connect-query'),
       `({`,
       `  service: `, localName(service), `,`,
@@ -81,8 +81,8 @@ const generateServiceFile =
         f.print(makeJsDoc(method));
         f.print(
           `export const ${safeIdentifier(localName(method))} = { `,
-          `  ...queryService.${localName(method)},`,
-          `  ...`, f.import('createUnaryHooks', '@connectrpc/connect-query'),`(queryService.${localName(method)})`,
+          `  ...$queryService.${localName(method)},`,
+          `  ...`, f.import('createUnaryHooks', '@connectrpc/connect-query'),`($queryService.${localName(method)})`,
           `};`
         );
 

--- a/packages/protoc-gen-connect-query/src/generateTs.ts
+++ b/packages/protoc-gen-connect-query/src/generateTs.ts
@@ -66,22 +66,25 @@ const generateServiceFile =
     f.print("}", extension === "ts" ? " as const" : "", ";");
     f.print();
 
+    f.print(`const queryService = `,
+      f.import('createQueryService', '@connectrpc/connect-query'),
+      `({`,
+      `  service: `, localName(service), `,`,
+      `});`
+    );
+    f.print();
+
     
     service.methods
       .filter((method) => method.methodKind === MethodKind.Unary)
       .forEach((method, index, filteredMethods) => {
         f.print(makeJsDoc(method));
         f.print(
-          `export const ${safeIdentifier(localName(method))} = `,
-          f.import('createQueryService', '@connectrpc/connect-query'),
-          `({`,
+          `export const ${safeIdentifier(localName(method))} = { `,
+          `  ...queryService.${localName(method)},`,
+          `  ...`, f.import('createHooks', '@connectrpc/connect-query'),`(queryService.${localName(method)})`,
+          `};`
         );
-        f.print(`  service: `, localName(service), `,`);
-        // Note, the reason for dot accessing the method rather than destructuring at the top is that it allows for a
-        // TSDoc to be attached to the exported variable. Also, it's nice that each method has its own atomic section
-        // that you could independently inspect and debug (i.e. commenting a single method is much easier when it's one
-        // contiguous set of lines).
-        f.print(`}).${localName(method)};`);
 
         const lastIndex = index === filteredMethods.length - 1;
         if (!lastIndex) {


### PR DESCRIPTION
Less reliance on React specific APIs (in the core of connect-query) allows the core API to adapt better to scenarios like Server Components or other frameworks.

This PR keeps the existing plugin API (while adding some new methods) but frees us up to be more selective about the react APIs we NEED for other future plugins.

## Changes in `@connectrpc/connect-query`

### Breaking changes
- Removed `UnaryHooks` type and replaced with `UnaryFunctionsWithHooks`
- Updated `createUnaryHooks` to only return the hooks and not other functions
 
### New functions

### createUnaryFunctions

Introduced `createUnaryFunctions` which can be used with the new `createUnaryHooks` to do the same thing as the old `createUnaryHooks`. The reasoning behind this change is to prep the core library, `connect-query`, to be able to used separately from React itself and this is just the first step in that direction.

## Changes in code generated by `protoc-gen-connect-query` and `protoc-gen-connect-query-react`

### New functions

Each service method now generates two new functions associated to the method:

#### method.createUseInfiniteQueryOptions

This method creates options that will pass to `useInfiniteQuery`. It is identical to `method.useInfiniteQuery` except it needs to be passed a transport directly.

#### createUseMutationOptions

This method creates options that will pass to `useMutation`. It is identical to `method.useMutation` except it needs to be passed a transport directly.

We added these methods to better future-proof the code for incoming changes to React (React Server Components, etc).  