### PR TITLE
Loosen peer dependency requirement

### DIFF
--- a/packages/connect-query/package.json
+++ b/packages/connect-query/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "^1.3.3",
     "@connectrpc/connect": "^1.1.2",
-    "@tanstack/react-query": "^5.4.3",
+    "@tanstack/react-query": "5.x",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Fixes #305 

We don't need such a restrictive peer dependency. Anything in 5.x will do.