### PR TITLE
Fix dual package hazard in nodejs

### DIFF
--- a/packages/connect-query/package.json
+++ b/packages/connect-query/package.json
@@ -24,9 +24,13 @@
   "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
+      "node": {
+        "import": "./dist/proxy/index.js",
+        "require": "./dist/cjs/index.js"
+      },
       "module": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/proxy/index.js"
+      "import": "./dist/proxy/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #305 

For more details, see https://github.com/bufbuild/protobuf-es/issues/610 but the long story short is that module systems in nodejs/browser continue to hurt everyone involved.