### PR TITLE
Make sure to take into account enabled queryOption

### DIFF
--- a/packages/connect-query/src/use-query.test.ts
+++ b/packages/connect-query/src/use-query.test.ts
@@ -123,6 +123,42 @@ describe("useQuery", () => {
 
     expect(result.current.data).toBe(6);
   });
+
+  it("can be disabled without explicit disableQuery", () => {
+    const { result } = renderHook(
+      () => {
+        return useQuery(
+          sayMethodDescriptor,
+          {
+            sentence: "hello",
+          },
+          {
+            enabled: false,
+          },
+        );
+      },
+      wrapper({}, mockedElizaTransport),
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBeTruthy();
+    expect(result.current.isFetching).toBeFalsy();
+  });
+
+  it("disableQuery will override explicit enabled", () => {
+    const { result } = renderHook(
+      () => {
+        return useQuery(sayMethodDescriptor, disableQuery, {
+          enabled: true,
+        });
+      },
+      wrapper({}, mockedElizaTransport),
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBeTruthy();
+    expect(result.current.isFetching).toBeFalsy();
+  });
 });
 
 describe("useSuspenseQuery", () => {

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -58,9 +58,13 @@ export function useQuery<
     transport: transport ?? transportFromCtx,
     callOptions,
   });
+  // The query cannot be enabled if the base options are disabled, regardless of
+  // incoming query options.
+  const enabled = baseOptions.enabled && (queryOptions.enabled ?? true);
   return tsUseQuery({
     ...queryOptions,
     ...baseOptions,
+    enabled,
   });
 }
 


### PR DESCRIPTION
Fixes #317 

Incoming queryOption should be taken into account for final enable status, just don't let it override the disableQuery input.
