### PR TITLE
Add a distinguishing factor between infinite query keys and regular query keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ function useQuery<I extends Message<I>, O extends Message<O>>(
   options?: {
     transport?: Transport;
     callOptions?: CallOptions;
-  } & UseQueryOptions
+  } & UseQueryOptions,
 ): UseQueryResult<O, ConnectError>;
 ```
 
@@ -219,7 +219,7 @@ function useInfiniteQuery<
     transport?: Transport;
     callOptions?: CallOptions;
     getNextPageParam: GetNextPageParamFunction<PartialMessage<I>[ParamKey], O>;
-  }
+  },
 ): UseInfiniteQueryResult<InfiniteData<O>, ConnectError>;
 ```
 
@@ -252,7 +252,7 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 ```ts
 function createConnectQueryKey<I extends Message<I>, O extends Message<O>>(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
-  input?: DisableQuery | PartialMessage<I> | undefined
+  input?: DisableQuery | PartialMessage<I> | undefined,
 ): ConnectQueryKey<I>;
 ```
 
@@ -267,7 +267,7 @@ function createConnectInfiniteQueryKey<
 >(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
   input: DisableQuery | PartialMessage<I>,
-  pageParamKey: keyof PartialMessage<I>
+  pageParamKey: keyof PartialMessage<I>,
 ): ConnectInfiniteQueryKey<I>;
 ```
 
@@ -285,7 +285,7 @@ function callUnaryMethod<I extends Message<I>, O extends Message<O>>(
   }: {
     transport: Transport;
     callOptions?: CallOptions | undefined;
-  }
+  },
 ): Promise<O>;
 ```
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ function useQuery<I extends Message<I>, O extends Message<O>>(
   options?: {
     transport?: Transport;
     callOptions?: CallOptions;
-  } & UseQueryOptions,
+  } & UseQueryOptions
 ): UseQueryResult<O, ConnectError>;
 ```
 
@@ -219,7 +219,7 @@ function useInfiniteQuery<
     transport?: Transport;
     callOptions?: CallOptions;
     getNextPageParam: GetNextPageParamFunction<PartialMessage<I>[ParamKey], O>;
-  },
+  }
 ): UseInfiniteQueryResult<InfiniteData<O>, ConnectError>;
 ```
 
@@ -252,11 +252,26 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 ```ts
 function createConnectQueryKey<I extends Message<I>, O extends Message<O>>(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
-  input?: DisableQuery | PartialMessage<I> | undefined,
+  input?: DisableQuery | PartialMessage<I> | undefined
 ): ConnectQueryKey<I>;
 ```
 
 This helper is useful to manually compute the [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) sent to TanStack Query. This function has no side effects.
+
+### `createConnectInfiniteQueryKey`
+
+```ts
+function createConnectInfiniteQueryKey<
+  I extends Message<I>,
+  O extends Message<O>,
+>(
+  methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
+  input: DisableQuery | PartialMessage<I>,
+  pageParamKey: keyof PartialMessage<I>
+): ConnectInfiniteQueryKey<I>;
+```
+
+This function is not really necessary unless you are manually creating infinite query keys. When invalidating queries, it usually makes more sense to use the `createConnectQueryKey` function instead since it will also invalidate the regular queries (as well as the infinite queries).
 
 ### `callUnaryMethod`
 
@@ -270,7 +285,7 @@ function callUnaryMethod<I extends Message<I>, O extends Message<O>>(
   }: {
     transport: Transport;
     callOptions?: CallOptions | undefined;
-  },
+  }
 ): Promise<O>;
 ```
 
@@ -326,6 +341,19 @@ For example, a partial query key might look like this:
 
 ```ts
 ["example.v1.ExampleService", "GetTodos"];
+```
+
+### `ConnectInfiniteQueryKey`
+
+Similar to `ConnectQueryKey`, but for infinite queries.
+
+```ts
+type ConnectInfiniteQueryKey<I extends Message<I>> = [
+  serviceTypeName: string,
+  methodName: string,
+  input: PartialMessage<I>,
+  "infinite",
+];
 ```
 
 ## Testing

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -58,3 +58,26 @@ export function createConnectQueryKey<
     input === disableQuery || !input ? {} : input,
   ];
 }
+
+/**
+ * Similar to @see ConnectQueryKey, but for infinite queries.
+ */
+export type ConnectInfiniteQueryKey<I extends Message<I>> = [
+  serviceTypeName: string,
+  methodName: string,
+  input: PartialMessage<I>,
+  "infinite",
+];
+
+/**
+ * Similar to @see createConnectQueryKey, but for infinite queries.
+ */
+export function createConnectInfiniteQueryKey<
+  I extends Message<I>,
+  O extends Message<O>,
+>(
+  methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
+  input?: DisableQuery | PartialMessage<I> | undefined,
+): ConnectInfiniteQueryKey<I> {
+  return [...createConnectQueryKey(methodDescriptor, input), "infinite"];
+}

--- a/packages/connect-query/src/create-use-infinite-query-options.ts
+++ b/packages/connect-query/src/create-use-infinite-query-options.ts
@@ -25,7 +25,7 @@ import type {
 import { callUnaryMethod } from "./call-unary-method.js";
 import {
   type ConnectInfiniteQueryKey,
-  createConnectQueryKey,
+  createConnectInfiniteQueryKey,
 } from "./connect-query-key.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { assert, type DisableQuery, disableQuery } from "./utils.js";
@@ -103,7 +103,7 @@ function createUnaryInfiniteQueryFn<
     transport: Transport;
     callOptions?: CallOptions | undefined;
     pageParamKey: ParamKey;
-  },
+  }
 ): QueryFunction<O, ConnectInfiniteQueryKey<I>, PartialMessage<I>[ParamKey]> {
   return async (context) => {
     assert(input !== disableQuery, "Disabled query cannot be fetched");
@@ -142,7 +142,7 @@ export function createUseInfiniteQueryOptions<
     getNextPageParam,
     pageParamKey,
     callOptions,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey>
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,
@@ -158,14 +158,14 @@ export function createUseInfiniteQueryOptions<
   initialPageParam: PartialMessage<I>[ParamKey];
   enabled: boolean;
 } {
-  const queryKey = createConnectQueryKey(
+  const queryKey = createConnectInfiniteQueryKey(
     methodSig,
     input === disableQuery
       ? undefined
       : {
           ...input,
           [pageParamKey]: undefined,
-        },
+        }
   );
   return {
     getNextPageParam,
@@ -173,7 +173,7 @@ export function createUseInfiniteQueryOptions<
       input === disableQuery
         ? undefined
         : (input[pageParamKey] as PartialMessage<I>[ParamKey]),
-    queryKey: [...queryKey, "infinite"],
+    queryKey,
     queryFn: createUnaryInfiniteQueryFn(methodSig, input, {
       transport,
       callOptions,

--- a/packages/connect-query/src/create-use-infinite-query-options.ts
+++ b/packages/connect-query/src/create-use-infinite-query-options.ts
@@ -103,7 +103,7 @@ function createUnaryInfiniteQueryFn<
     transport: Transport;
     callOptions?: CallOptions | undefined;
     pageParamKey: ParamKey;
-  }
+  },
 ): QueryFunction<O, ConnectInfiniteQueryKey<I>, PartialMessage<I>[ParamKey]> {
   return async (context) => {
     assert(input !== disableQuery, "Disabled query cannot be fetched");
@@ -142,7 +142,7 @@ export function createUseInfiniteQueryOptions<
     getNextPageParam,
     pageParamKey,
     callOptions,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey>
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,
@@ -165,7 +165,7 @@ export function createUseInfiniteQueryOptions<
       : {
           ...input,
           [pageParamKey]: undefined,
-        }
+        },
   );
   return {
     getNextPageParam,

--- a/packages/connect-query/src/create-use-infinite-query-options.ts
+++ b/packages/connect-query/src/create-use-infinite-query-options.ts
@@ -24,7 +24,7 @@ import type {
 
 import { callUnaryMethod } from "./call-unary-method.js";
 import {
-  type ConnectQueryKey,
+  type ConnectInfiniteQueryKey,
   createConnectQueryKey,
 } from "./connect-query-key.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
@@ -62,7 +62,7 @@ export type CreateInfiniteQueryOptions<
       ConnectError,
       InfiniteData<O>,
       O,
-      ConnectQueryKey<I>,
+      ConnectInfiniteQueryKey<I>,
       PartialMessage<I>[ParamKey]
     >,
     "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
@@ -82,7 +82,7 @@ export type CreateSuspenseInfiniteQueryOptions<
       ConnectError,
       InfiniteData<O>,
       O,
-      ConnectQueryKey<I>,
+      ConnectInfiniteQueryKey<I>,
       PartialMessage<I>[ParamKey]
     >,
     "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
@@ -104,7 +104,7 @@ function createUnaryInfiniteQueryFn<
     callOptions?: CallOptions | undefined;
     pageParamKey: ParamKey;
   },
-): QueryFunction<O, ConnectQueryKey<I>, PartialMessage<I>[ParamKey]> {
+): QueryFunction<O, ConnectInfiniteQueryKey<I>, PartialMessage<I>[ParamKey]> {
   return async (context) => {
     assert(input !== disableQuery, "Disabled query cannot be fetched");
     assert("pageParam" in context, "pageParam must be part of context");
@@ -149,8 +149,12 @@ export function createUseInfiniteQueryOptions<
     O,
     ParamKey
   >["getNextPageParam"];
-  queryKey: ConnectQueryKey<I>;
-  queryFn: QueryFunction<O, ConnectQueryKey<I>, PartialMessage<I>[ParamKey]>;
+  queryKey: ConnectInfiniteQueryKey<I>;
+  queryFn: QueryFunction<
+    O,
+    ConnectInfiniteQueryKey<I>,
+    PartialMessage<I>[ParamKey]
+  >;
   initialPageParam: PartialMessage<I>[ParamKey];
   enabled: boolean;
 } {
@@ -169,7 +173,7 @@ export function createUseInfiniteQueryOptions<
       input === disableQuery
         ? undefined
         : (input[pageParamKey] as PartialMessage<I>[ParamKey]),
-    queryKey,
+    queryKey: [...queryKey, "infinite"],
     queryFn: createUnaryInfiniteQueryFn(methodSig, input, {
       transport,
       callOptions,

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type { ConnectQueryKey } from "./connect-query-key.js";
-export { createConnectQueryKey } from "./connect-query-key.js";
+export type {
+  ConnectQueryKey,
+  ConnectInfiniteQueryKey,
+} from "./connect-query-key.js";
+export {
+  createConnectQueryKey,
+  createConnectInfiniteQueryKey,
+} from "./connect-query-key.js";
 export { disableQuery, createProtobufSafeUpdater } from "./utils.js";
 export { useTransport, TransportProvider } from "./use-transport.js";
 export type { CreateInfiniteQueryOptions as UseInfiniteQueryOptions } from "./create-use-infinite-query-options.js";

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -53,15 +53,15 @@ describe("useInfiniteQuery", () => {
           {
             getNextPageParam: (lastPage) => lastPage.page + 1n,
             pageParamKey: "page",
-          }
+          },
         );
       },
       wrapper(
         {
           defaultOptions,
         },
-        mockedPaginatedTransport
-      )
+        mockedPaginatedTransport,
+      ),
     );
 
     await waitFor(() => {
@@ -106,7 +106,7 @@ describe("useInfiniteQuery", () => {
           pageParamKey: "page",
         });
       },
-      wrapper(undefined, mockedPaginatedTransport)
+      wrapper(undefined, mockedPaginatedTransport),
     );
     expect(result.current.isPending).toBeTruthy();
     expect(result.current.isFetching).toBeFalsy();
@@ -127,15 +127,15 @@ describe("useInfiniteQuery", () => {
               items: ["Intercepted!"],
               page: 0n,
             }),
-          }
+          },
         );
       },
       wrapper(
         {
           defaultOptions,
         },
-        mockedPaginatedTransport
-      )
+        mockedPaginatedTransport,
+      ),
     );
     await waitFor(() => {
       expect(result.current.isSuccess).toBeTruthy();
@@ -165,15 +165,15 @@ describe("useInfiniteQuery", () => {
                 }),
               ],
             },
-          }
+          },
         );
       },
       wrapper(
         {
           defaultOptions,
         },
-        mockedPaginatedTransport
-      )
+        mockedPaginatedTransport,
+      ),
     );
     expect(result.current.data?.pages[0].page).toEqual(-1n);
   });
@@ -183,7 +183,7 @@ describe("useInfiniteQuery", () => {
       {
         defaultOptions,
       },
-      mockedPaginatedTransport
+      mockedPaginatedTransport,
     );
     const { result } = renderHook(() => {
       return useInfiniteQuery(
@@ -194,7 +194,7 @@ describe("useInfiniteQuery", () => {
         {
           getNextPageParam: (lastPage) => lastPage.page + 1n,
           pageParamKey: "page",
-        }
+        },
       );
     }, remainingWrapper);
 
@@ -202,7 +202,7 @@ describe("useInfiniteQuery", () => {
 
     expect(cache).toHaveLength(1);
     expect(cache[0].queryKey).toEqual(
-      createConnectInfiniteQueryKey(methodDescriptor, {})
+      createConnectInfiniteQueryKey(methodDescriptor, {}),
     );
 
     await waitFor(() => {
@@ -217,7 +217,7 @@ describe("useInfiniteQuery", () => {
       {
         defaultOptions,
       },
-      mockedPaginatedTransport
+      mockedPaginatedTransport,
     );
     const { result } = renderHook(() => {
       return useInfiniteQuery(
@@ -228,7 +228,7 @@ describe("useInfiniteQuery", () => {
         {
           getNextPageParam: (lastPage) => lastPage.page + 1n,
           pageParamKey: "page",
-        }
+        },
       );
     }, remainingWrapper);
     await waitFor(() => {
@@ -261,7 +261,7 @@ describe("useInfiniteQuery", () => {
         defaultOptions,
         queryCache: spiedQueryCache,
       },
-      mockedPaginatedTransport
+      mockedPaginatedTransport,
     );
     const { result } = renderHook(() => {
       return useInfiniteQuery(
@@ -272,7 +272,7 @@ describe("useInfiniteQuery", () => {
         {
           getNextPageParam: (lastPage) => lastPage.page + 1n,
           pageParamKey: "page",
-        }
+        },
       );
     }, remainingWrapper);
 
@@ -302,15 +302,15 @@ describe("useSuspenseInfiniteQuery", () => {
           {
             getNextPageParam: (lastPage) => lastPage.page + 1n,
             pageParamKey: "page",
-          }
+          },
         );
       },
       wrapper(
         {
           defaultOptions,
         },
-        mockedPaginatedTransport
-      )
+        mockedPaginatedTransport,
+      ),
     );
 
     await waitFor(() => {


### PR DESCRIPTION
Introduces a unique key for infinite queries so there's no chance to overlap and cause issues with shared cache.

This change introduces a new function and a new type:

- `ConnectInfiniteQueryKey` which is just the original `ConnectInfiniteQueryKey` with an added param to indicate it's for infinite queries
- `createConnectInifiniteQueryKey` which will create the above type.

This is technically a breaking change from a type perspective, though behaviour changes should be kept at a minimum since the key created by `createConnectQueryKey` will still work to invalidate infinite queries (unless the `exact` parameter is provided).

Fixes #328.