### PR TITLE
Add support for enabled to useInfiniteQuery

### DIFF
--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -346,4 +346,32 @@ describe("useSuspenseInfiniteQuery", () => {
       ],
     });
   });
+
+  it("can be disabled without explicit disableQuery", () => {
+    const { result } = renderHook(
+      () => {
+        return useInfiniteQuery(
+          methodDescriptor,
+          {
+            page: 0n,
+          },
+          {
+            getNextPageParam: (lastPage) => lastPage.page + 1n,
+            pageParamKey: "page",
+            enabled: false,
+          },
+        );
+      },
+      wrapper(
+        {
+          defaultOptions,
+        },
+        mockedPaginatedTransport,
+      ),
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBeTruthy();
+    expect(result.current.isFetching).toBeFalsy();
+  });
 });

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -64,7 +64,10 @@ export function useInfiniteQuery<
     pageParamKey,
     callOptions,
   });
-  return tsUseInfiniteQuery({ ...options, ...baseOptions });
+  // The query cannot be enabled if the base options are disabled, regardless of
+  // incoming query options.
+  const enabled = baseOptions.enabled && (options.enabled ?? true);
+  return tsUseInfiniteQuery({ ...options, ...baseOptions, enabled });
 }
 
 /**


### PR DESCRIPTION
Porting support that was already added to `useQuery` in #318.

Fixes #336 