### PR TITLE
Expose internal methods used to create query options

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ function useQuery<I extends Message<I>, O extends Message<O>>(
   options?: {
     transport?: Transport;
     callOptions?: CallOptions;
-  } & UseQueryOptions,
+  } & UseQueryOptions
 ): UseQueryResult<O, ConnectError>;
 ```
 
@@ -219,7 +219,7 @@ function useInfiniteQuery<
     transport?: Transport;
     callOptions?: CallOptions;
     getNextPageParam: GetNextPageParamFunction<PartialMessage<I>[ParamKey], O>;
-  },
+  }
 ): UseInfiniteQueryResult<InfiniteData<O>, ConnectError>;
 ```
 
@@ -252,7 +252,7 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 ```ts
 function createConnectQueryKey<I extends Message<I>, O extends Message<O>>(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
-  input?: DisableQuery | PartialMessage<I> | undefined,
+  input?: DisableQuery | PartialMessage<I> | undefined
 ): ConnectQueryKey<I>;
 ```
 
@@ -267,7 +267,7 @@ function createConnectInfiniteQueryKey<
 >(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
   input: DisableQuery | PartialMessage<I>,
-  pageParamKey: keyof PartialMessage<I>,
+  pageParamKey: keyof PartialMessage<I>
 ): ConnectInfiniteQueryKey<I>;
 ```
 
@@ -285,7 +285,7 @@ function callUnaryMethod<I extends Message<I>, O extends Message<O>>(
   }: {
     transport: Transport;
     callOptions?: CallOptions | undefined;
-  },
+  }
 ): Promise<O>;
 ```
 
@@ -312,6 +312,14 @@ queryClient.setQueryData(
 );
 
 ```
+
+### `createUseQueryOptions`
+
+A functional version of the options usually passed the underlying `useQuery` hook. This is useful when interacting with `useQueries` API or queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
+
+### `createUseInfiniteQueryOptions`
+
+A functional version of the options usually passed the underlying `useInfiniteQuery` hook. This is useful when interacting with some queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
 
 ### `ConnectQueryKey`
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Connect-Query is an wrapper around [TanStack Query](https://tanstack.com/query) 
   - [`createConnectQueryKey`](#createconnectquerykey)
   - [`callUnaryMethod`](#callunarymethod)
   - [`createProtobufSafeUpdater`](#createprotobufsafeupdater)
-  - [`createUseQueryOptions`](#createusequeryoptions)
-  - [`createUseInfiniteQueryOptions`](#createuseinfinitequeryoptions)
+  - [`createQueryOptions`](#createqueryoptions)
+  - [`createInfiniteQueryOptions`](#createinfinitequeryoptions)
   - [`ConnectQueryKey`](#connectquerykey)
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -340,14 +340,14 @@ An example of how to use this function with `useQueries`:
 
 ```ts
 import { useQueries } from "@tanstack/react-query";
-import { createUseQueryOptions, useTransport } from "@connectrpc/connect-query";
+import { createQueryOptions, useTransport } from "@connectrpc/connect-query";
 import { example } from "your-generated-code/example-ExampleService_connectquery";
 
 const MyComponent = () => {
   const transport = useTransport();
   const [query1, query2] = useQueries([
-    createUseQueryOptions(example, { sentence: "First query" }, { transport }),
-    createUseQueryOptions(example, { sentence: "Second query" }, { transport }),
+    createQueryOptions(example, { sentence: "First query" }, { transport }),
+    createQueryOptions(example, { sentence: "Second query" }, { transport }),
   ]);
   ...
 };

--- a/README.md
+++ b/README.md
@@ -319,6 +319,23 @@ queryClient.setQueryData(
 
 A functional version of the options usually passed the underlying `useQuery` hook. This is useful when interacting with `useQueries` API or queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
 
+An example of how to use this function with `useQueries`:
+
+```ts
+import { useQueries } from "@tanstack/react-query";
+import { createUseQueryOptions, useTransport } from "@connectrpc/connect-query";
+import { example } from "your-generated-code/example-ExampleService_connectquery";
+
+const MyComponent = () => {
+  const transport = useTransport();
+  const [query1, query2] = useQueries([
+    createUseQueryOptions(example, { sentence: "First query" }, { transport }),
+    createUseQueryOptions(example, { sentence: "Second query" }, { transport }),
+  ]);
+  ...
+};
+```
+
 ### `createUseInfiniteQueryOptions`
 
 A functional version of the options usually passed the underlying `useInfiniteQuery` hook. This is useful when interacting with some queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Connect-Query is an wrapper around [TanStack Query](https://tanstack.com/query) 
   - [`createConnectQueryKey`](#createconnectquerykey)
   - [`callUnaryMethod`](#callunarymethod)
   - [`createProtobufSafeUpdater`](#createprotobufsafeupdater)
+  - [`createUseQueryOptions`](#createusequeryoptions)
+  - [`createUseInfiniteQueryOptions`](#createuseinfinitequeryoptions)
   - [`ConnectQueryKey`](#connectquerykey)
 
 ## Quickstart
@@ -191,7 +193,7 @@ function useQuery<I extends Message<I>, O extends Message<O>>(
   options?: {
     transport?: Transport;
     callOptions?: CallOptions;
-  } & UseQueryOptions
+  } & UseQueryOptions,
 ): UseQueryResult<O, ConnectError>;
 ```
 
@@ -219,7 +221,7 @@ function useInfiniteQuery<
     transport?: Transport;
     callOptions?: CallOptions;
     getNextPageParam: GetNextPageParamFunction<PartialMessage<I>[ParamKey], O>;
-  }
+  },
 ): UseInfiniteQueryResult<InfiniteData<O>, ConnectError>;
 ```
 
@@ -252,7 +254,7 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 ```ts
 function createConnectQueryKey<I extends Message<I>, O extends Message<O>>(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
-  input?: DisableQuery | PartialMessage<I> | undefined
+  input?: DisableQuery | PartialMessage<I> | undefined,
 ): ConnectQueryKey<I>;
 ```
 
@@ -267,7 +269,7 @@ function createConnectInfiniteQueryKey<
 >(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
   input: DisableQuery | PartialMessage<I>,
-  pageParamKey: keyof PartialMessage<I>
+  pageParamKey: keyof PartialMessage<I>,
 ): ConnectInfiniteQueryKey<I>;
 ```
 
@@ -285,7 +287,7 @@ function callUnaryMethod<I extends Message<I>, O extends Message<O>>(
   }: {
     transport: Transport;
     callOptions?: CallOptions | undefined;
-  }
+  },
 ): Promise<O>;
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,9 +315,26 @@ queryClient.setQueryData(
 
 ```
 
-### `createUseQueryOptions`
+### `createQueryOptions`
 
-A functional version of the options usually passed the underlying `useQuery` hook. This is useful when interacting with `useQueries` API or queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
+```ts
+function createQueryOptions<I extends Message<I>, O extends Message<O>>(
+  methodSig: MethodUnaryDescriptor<I, O>,
+  input: DisableQuery | PartialMessage<I> | undefined,
+  {
+    transport,
+    callOptions,
+  }: ConnectQueryOptions & {
+    transport: Transport;
+  },
+): {
+  queryKey: ConnectQueryKey<I>;
+  queryFn: QueryFunction<O, ConnectQueryKey<I>>;
+  enabled: boolean;
+};
+```
+
+A functional version of the options that can be passed to the `useQuery` hook from `@tanstack/react-query`. When called, it will return the appropriate `queryKey`, `queryFn`, and `enabled` flag. This is useful when interacting with `useQueries` API or queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
 
 An example of how to use this function with `useQueries`:
 
@@ -336,9 +353,41 @@ const MyComponent = () => {
 };
 ```
 
-### `createUseInfiniteQueryOptions`
+### `createInfiniteQueryOptions`
 
-A functional version of the options usually passed the underlying `useInfiniteQuery` hook. This is useful when interacting with some queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
+```ts
+function createInfiniteQueryOptions<
+  I extends Message<I>,
+  O extends Message<O>,
+  ParamKey extends keyof PartialMessage<I>,
+  Input extends PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
+>(
+  methodSig: MethodUnaryDescriptor<I, O>,
+  input: DisableQuery | Input,
+  {
+    transport,
+    getNextPageParam,
+    pageParamKey,
+    callOptions,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
+): {
+  getNextPageParam: ConnectInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey
+  >["getNextPageParam"];
+  queryKey: ConnectInfiniteQueryKey<I>;
+  queryFn: QueryFunction<
+    O,
+    ConnectInfiniteQueryKey<I>,
+    PartialMessage<I>[ParamKey]
+  >;
+  initialPageParam: PartialMessage<I>[ParamKey];
+  enabled: boolean;
+};
+```
+
+A functional version of the options that can be passed to the `useInfiniteQuery` hook from `@tanstack/react-query`.When called, it will return the appropriate `queryKey`, `queryFn`, and `enabled` flags, as well as a few other parameters required for `useInfiniteQuery`. This is useful when interacting with some queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
 
 ### `ConnectQueryKey`
 

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -35,3 +35,5 @@ export { defaultOptions } from "./default-options.js";
 export type { DisableQuery, ConnectUpdater } from "./utils.js";
 export { callUnaryMethod } from "./call-unary-method.js";
 export type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
+export { createUseInfiniteQueryOptions } from "./create-use-infinite-query-options.js";
+export { createUseQueryOptions } from "./create-use-query-options.js";

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -35,5 +35,5 @@ export { defaultOptions } from "./default-options.js";
 export type { DisableQuery, ConnectUpdater } from "./utils.js";
 export { callUnaryMethod } from "./call-unary-method.js";
 export type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
-export { createUseInfiniteQueryOptions } from "./create-use-infinite-query-options.js";
-export { createUseQueryOptions } from "./create-use-query-options.js";
+export { createUseInfiniteQueryOptions as createInfiniteQueryOptions } from "./create-use-infinite-query-options.js";
+export { createUseQueryOptions as createQueryOptions } from "./create-use-query-options.js";


### PR DESCRIPTION
Ideally we'd be able to create an opinionated version of `useQueries` but due to the complexity of those recursive types and there still being other queryClient methods that can benefit from these APIs, I propose we expose these internal APIs as helpers.

Fixes #333
Fixes #296 