### PR TITLE
Prevent using extendible input type

### DIFF
--- a/packages/connect-query/src/create-use-infinite-query-options.ts
+++ b/packages/connect-query/src/create-use-infinite-query-options.ts
@@ -133,10 +133,11 @@ export function createUseInfiniteQueryOptions<
   I extends Message<I>,
   O extends Message<O>,
   ParamKey extends keyof PartialMessage<I>,
-  Input extends PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
 >(
   methodSig: MethodUnaryDescriptor<I, O>,
-  input: DisableQuery | Input,
+  input:
+    | DisableQuery
+    | (PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>),
   {
     transport,
     getNextPageParam,

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -374,4 +374,30 @@ describe("useSuspenseInfiniteQuery", () => {
     expect(result.current.isPending).toBeTruthy();
     expect(result.current.isFetching).toBeFalsy();
   });
+
+  // eslint-disable-next-line jest/expect-expect -- We are asserting via @ts-expect-error
+  it("does not allow excess properties", () => {
+    renderHook(
+      () => {
+        return useInfiniteQuery(
+          methodDescriptor,
+          {
+            page: 0n,
+            // @ts-expect-error(2345) extra fields should not be allowed
+            extraField: "extra",
+          },
+          {
+            getNextPageParam: (lastPage) => lastPage.page + 1n,
+            pageParamKey: "page",
+          },
+        );
+      },
+      wrapper(
+        {
+          defaultOptions,
+        },
+        mockedPaginatedTransport,
+      ),
+    );
+  });
 });

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -43,10 +43,11 @@ export function useInfiniteQuery<
   I extends Message<I>,
   O extends Message<O>,
   ParamKey extends keyof PartialMessage<I>,
-  Input extends PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
 >(
   methodSig: MethodUnaryDescriptor<I, O>,
-  input: DisableQuery | Input,
+  input:
+    | DisableQuery
+    | (PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>),
   {
     transport,
     callOptions,
@@ -80,10 +81,9 @@ export function useSuspenseInfiniteQuery<
   I extends Message<I>,
   O extends Message<O>,
   ParamKey extends keyof PartialMessage<I>,
-  Input extends PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
 >(
   methodSig: MethodUnaryDescriptor<I, O>,
-  input: Input,
+  input: PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
   {
     transport,
     callOptions,


### PR DESCRIPTION
Remove unnecessary extends generics.

Fixes #342 