### PR TITLE
Make sure generated keys include defaults

### DIFF
--- a/packages/connect-query/eliza.proto
+++ b/packages/connect-query/eliza.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package connectrpc.eliza.v1;
 
+import "google/protobuf/timestamp.proto";
+
 // ElizaService provides a way to talk to Eliza, a port of the DOCTOR script
 // for Joseph Weizenbaum's original ELIZA program. Created in the mid-1960s at
 // the MIT Artificial Intelligence Laboratory, ELIZA demonstrates the
@@ -115,4 +117,16 @@ message ListResponse {
 
 service PaginatedService {
   rpc List(ListRequest) returns (ListResponse);
+}
+
+message OperationRequest {
+  google.protobuf.Timestamp timestamp = 1;
+}
+
+message OperationResponse {
+  google.protobuf.Timestamp timestamp = 1;
+}
+
+service ServiceWithMessage {
+  rpc Operation(OperationRequest) returns (OperationResponse);
 }

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Timestamp, toPlainMessage } from "@bufbuild/protobuf";
 import { describe, expect, it } from "@jest/globals";
 
 import { createConnectQueryKey } from "./connect-query-key.js";
-import { SayRequest } from "./gen/eliza_pb.js";
+import { OperationRequest, SayRequest } from "./gen/eliza_pb.js";
 import { disableQuery } from "./utils.js";
 
 describe("makeQueryKey", () => {
@@ -40,11 +41,33 @@ describe("makeQueryKey", () => {
 
   it("allows empty inputs", () => {
     const key = createConnectQueryKey(methodDescriptor);
-    expect(key).toStrictEqual(["service.typeName", "name", {}]);
+    expect(key).toStrictEqual([
+      "service.typeName",
+      "name",
+      toPlainMessage(new methodDescriptor.I({})),
+    ]);
   });
 
   it("makes a query key with a disabled input", () => {
     const key = createConnectQueryKey(methodDescriptor, disableQuery);
-    expect(key).toStrictEqual(["service.typeName", "name", {}]);
+    expect(key).toStrictEqual([
+      "service.typeName",
+      "name",
+      toPlainMessage(new methodDescriptor.I({})),
+    ]);
+  });
+
+  it("converts nested Timestamps to PlainMessages", () => {
+    const methodDescriptorWithMessage = {
+      I: OperationRequest,
+      name: "name",
+      service: {
+        typeName: "service.typeName",
+      },
+    };
+    const key = createConnectQueryKey(methodDescriptorWithMessage, {
+      timestamp: new Timestamp(),
+    });
+    expect(key[2].timestamp).not.toBeInstanceOf(Timestamp);
   });
 });

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -71,7 +71,7 @@ describe("makeQueryKey", () => {
     expect(key[2].timestamp).not.toBeInstanceOf(Timestamp);
   });
 
-  it("generates identical keys with default as well as when default is provided", () => {
+  it("generates identical keys when input is empty or the default is explicitly sent", () => {
     const key1 = createConnectQueryKey(methodDescriptor, {});
     const key2 = createConnectQueryKey(methodDescriptor, { sentence: "" });
     expect(key1).toStrictEqual(key2);

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -70,4 +70,10 @@ describe("makeQueryKey", () => {
     });
     expect(key[2].timestamp).not.toBeInstanceOf(Timestamp);
   });
+
+  it("key generated with default is the same as without the field", () => {
+    const key1 = createConnectQueryKey(methodDescriptor, {});
+    const key2 = createConnectQueryKey(methodDescriptor, { sentence: "" });
+    expect(key1).toStrictEqual(key2);
+  });
 });

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -71,7 +71,7 @@ describe("makeQueryKey", () => {
     expect(key[2].timestamp).not.toBeInstanceOf(Timestamp);
   });
 
-  it("key generated with default is the same as without the field", () => {
+  it("generates identical keys with default as well as when default is provided", () => {
     const key1 = createConnectQueryKey(methodDescriptor, {});
     const key2 = createConnectQueryKey(methodDescriptor, { sentence: "" });
     expect(key1).toStrictEqual(key2);

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { Message, PartialMessage } from "@bufbuild/protobuf";
+import {
+  type Message,
+  type PartialMessage,
+  type PlainMessage,
+  toPlainMessage,
+} from "@bufbuild/protobuf";
 
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import type { DisableQuery } from "./utils.js";
@@ -35,7 +40,7 @@ import { disableQuery } from "./utils.js";
 export type ConnectQueryKey<I extends Message<I>> = [
   serviceTypeName: string,
   methodName: string,
-  input: PartialMessage<I>,
+  input: PlainMessage<I>,
 ];
 
 /**
@@ -55,7 +60,9 @@ export function createConnectQueryKey<
   return [
     methodDescriptor.service.typeName,
     methodDescriptor.name,
-    input === disableQuery || !input ? {} : input,
+    input === disableQuery || !input
+      ? toPlainMessage(new methodDescriptor.I({}))
+      : toPlainMessage(new methodDescriptor.I(input)),
   ];
 }
 
@@ -65,7 +72,7 @@ export function createConnectQueryKey<
 export type ConnectInfiniteQueryKey<I extends Message<I>> = [
   serviceTypeName: string,
   methodName: string,
-  input: PartialMessage<I>,
+  input: PlainMessage<I>,
   "infinite",
 ];
 

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -60,9 +60,9 @@ export function createConnectQueryKey<
   return [
     methodDescriptor.service.typeName,
     methodDescriptor.name,
-    input === disableQuery || !input
-      ? toPlainMessage(new methodDescriptor.I({}))
-      : toPlainMessage(new methodDescriptor.I(input)),
+    toPlainMessage(
+      new methodDescriptor.I(input === disableQuery || !input ? {} : input),
+    ),
   ];
 }
 

--- a/packages/connect-query/src/gen/eliza_connect.ts
+++ b/packages/connect-query/src/gen/eliza_connect.ts
@@ -17,7 +17,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConverseRequest, ConverseResponse, CountRequest, CountResponse, IntroduceRequest, IntroduceResponse, ListRequest, ListResponse, Nothing, SayRequest, SayResponse } from "./eliza_pb.js";
+import { ConverseRequest, ConverseResponse, CountRequest, CountResponse, IntroduceRequest, IntroduceResponse, ListRequest, ListResponse, Nothing, OperationRequest, OperationResponse, SayRequest, SayResponse } from "./eliza_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -206,6 +206,24 @@ export const PaginatedService = {
       name: "List",
       I: ListRequest,
       O: ListResponse,
+      kind: MethodKind.Unary,
+    },
+  }
+} as const;
+
+/**
+ * @generated from service connectrpc.eliza.v1.ServiceWithMessage
+ */
+export const ServiceWithMessage = {
+  typeName: "connectrpc.eliza.v1.ServiceWithMessage",
+  methods: {
+    /**
+     * @generated from rpc connectrpc.eliza.v1.ServiceWithMessage.Operation
+     */
+    operation: {
+      name: "Operation",
+      I: OperationRequest,
+      O: OperationResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/packages/connect-query/src/gen/eliza_pb.ts
+++ b/packages/connect-query/src/gen/eliza_pb.ts
@@ -18,7 +18,7 @@
 // @ts-nocheck
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
+import { Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
 
 /**
  * SayRequest is a single-sentence request.
@@ -438,6 +438,80 @@ export class ListResponse extends Message<ListResponse> {
 
   static equals(a: ListResponse | PlainMessage<ListResponse> | undefined, b: ListResponse | PlainMessage<ListResponse> | undefined): boolean {
     return proto3.util.equals(ListResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message connectrpc.eliza.v1.OperationRequest
+ */
+export class OperationRequest extends Message<OperationRequest> {
+  /**
+   * @generated from field: google.protobuf.Timestamp timestamp = 1;
+   */
+  timestamp?: Timestamp;
+
+  constructor(data?: PartialMessage<OperationRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "connectrpc.eliza.v1.OperationRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "timestamp", kind: "message", T: Timestamp },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OperationRequest {
+    return new OperationRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): OperationRequest {
+    return new OperationRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OperationRequest {
+    return new OperationRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: OperationRequest | PlainMessage<OperationRequest> | undefined, b: OperationRequest | PlainMessage<OperationRequest> | undefined): boolean {
+    return proto3.util.equals(OperationRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message connectrpc.eliza.v1.OperationResponse
+ */
+export class OperationResponse extends Message<OperationResponse> {
+  /**
+   * @generated from field: google.protobuf.Timestamp timestamp = 1;
+   */
+  timestamp?: Timestamp;
+
+  constructor(data?: PartialMessage<OperationResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "connectrpc.eliza.v1.OperationResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "timestamp", kind: "message", T: Timestamp },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OperationResponse {
+    return new OperationResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): OperationResponse {
+    return new OperationResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OperationResponse {
+    return new OperationResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: OperationResponse | PlainMessage<OperationResponse> | undefined, b: OperationResponse | PlainMessage<OperationResponse> | undefined): boolean {
+    return proto3.util.equals(OperationResponse, a, b);
   }
 }
 

--- a/packages/connect-query/src/jest/test-utils.tsx
+++ b/packages/connect-query/src/jest/test-utils.tsx
@@ -20,6 +20,7 @@ import type { QueryClientConfig } from "@tanstack/react-query";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { JSXElementConstructor, PropsWithChildren } from "react";
 
+import { defaultOptions } from "../default-options.js";
 import {
   BigIntService,
   ElizaService,
@@ -47,7 +48,10 @@ export const wrapper = (
   transport: Transport;
   queryClientWrapper: JSXElementConstructor<PropsWithChildren>;
 } => {
-  const queryClient = new QueryClient(config);
+  const queryClient = new QueryClient({
+    defaultOptions,
+    ...config,
+  });
   return {
     wrapper: ({ children }) => (
       <TransportProvider transport={transport}>


### PR DESCRIPTION
With the current state, a generated key for a message with undefined fields and one with defined (but matching the default) fields will be different, meaning that duplicate requests can be made. This change ensures that all keys generated take into account default fields.

Fixes #361 