### PR TITLE
Respect enabled:false in QueryClient's default options

### DIFF
--- a/packages/connect-query/src/create-use-query-options.ts
+++ b/packages/connect-query/src/create-use-query-options.ts
@@ -100,7 +100,7 @@ export function createUseQueryOptions<
 ): {
   queryKey: ConnectQueryKey<I>;
   queryFn: QueryFunction<O, ConnectQueryKey<I>>;
-  enabled: boolean;
+  enabled: boolean | undefined;
 } {
   const queryKey = createConnectQueryKey(methodSig, input);
   return {
@@ -109,6 +109,6 @@ export function createUseQueryOptions<
       transport,
       callOptions,
     }),
-    enabled: input !== disableQuery,
+    enabled: input === disableQuery ? false : undefined,
   };
 }

--- a/packages/connect-query/src/use-query.test.ts
+++ b/packages/connect-query/src/use-query.test.ts
@@ -145,6 +145,52 @@ describe("useQuery", () => {
     expect(result.current.isFetching).toBeFalsy();
   });
 
+  it("can be disabled with QueryClient default options", () => {
+    const { result } = renderHook(
+      () => {
+        return useQuery(sayMethodDescriptor, {
+          sentence: "hello",
+        });
+      },
+      wrapper(
+        {
+          defaultOptions: {
+            queries: {
+              enabled: false,
+            },
+          },
+        },
+        mockedElizaTransport,
+      ),
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBeTruthy();
+    expect(result.current.isFetching).toBeFalsy();
+  });
+
+  it("cannot be enabled with QueryClient default options with explicit disableQuery", () => {
+    const { result } = renderHook(
+      () => {
+        return useQuery(sayMethodDescriptor, disableQuery);
+      },
+      wrapper(
+        {
+          defaultOptions: {
+            queries: {
+              enabled: true,
+            },
+          },
+        },
+        mockedElizaTransport,
+      ),
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBeTruthy();
+    expect(result.current.isFetching).toBeFalsy();
+  });
+
   it("disableQuery will override explicit enabled", () => {
     const { result } = renderHook(
       () => {

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -58,14 +58,18 @@ export function useQuery<
     transport: transport ?? transportFromCtx,
     callOptions,
   });
+  const { enabled: baseEnabled, ...baseRest } = baseOptions;
+  const tsOpts = {
+    ...queryOptions,
+    ...baseRest,
+  };
   // The query cannot be enabled if the base options are disabled, regardless of
   // incoming query options.
-  const enabled = baseOptions.enabled && (queryOptions.enabled ?? true);
-  return tsUseQuery({
-    ...queryOptions,
-    ...baseOptions,
-    enabled,
-  });
+  const enabled = baseEnabled ?? queryOptions.enabled;
+  if (enabled !== undefined) {
+    tsOpts.enabled = enabled;
+  }
+  return tsUseQuery(tsOpts);
 }
 
 /**


### PR DESCRIPTION
Currently, tanstack's `useQuery` is always passed `false` or `true` for `enabled`. But if a user hasn't provided any explicit enablement, either using `disableQuery` or `queryOptions`, then the `QueryClient`'s default options should be used, which requires making sure `enabled` is unset, not an explicit boolean value.