### PR TITLE
Fix link to examples

### DIFF
--- a/packages/connect-query/README.md
+++ b/packages/connect-query/README.md
@@ -4,4 +4,4 @@ This is the runtime library package for Connect-Query. You'll find its code gene
 
 Connect-Query is a wrapper around [TanStack Query](https://tanstack.com/query) (react-query), written in TypeScript and thoroughly tested. It enables effortless communication with servers that speak the [Connect Protocol](https://connectrpc.com/docs/protocol).
 
-To get started, head over to the [docs](https://github.com/connectrpc/connect-query-es) for a tutorial, or take a look at [our examples](https://github.com/connectrpc/connect-query-es/examples) for integration with various frameworks.
+To get started, head over to the [docs](https://github.com/connectrpc/connect-query-es) for a tutorial, or take a look at [our examples](https://github.com/connectrpc/connect-query-es/tree/main/examples).


### PR DESCRIPTION
Fixes #378 

This fixes the link to the examples directory and also removes the wording about 'various frameworks' since right now, we only show React and it's a bit misleading.