### PR TITLE
V2: Handle structural sharing

### DIFF
--- a/packages/connect-query/src/create-use-infinite-query-options.ts
+++ b/packages/connect-query/src/create-use-infinite-query-options.ts
@@ -23,6 +23,7 @@ import type {
   InfiniteData,
   QueryFunction,
   UseInfiniteQueryOptions,
+  UseQueryOptions,
   UseSuspenseInfiniteQueryOptions,
 } from "@tanstack/react-query";
 
@@ -32,6 +33,7 @@ import {
   createConnectInfiniteQueryKey,
 } from "./connect-query-key.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
+import { createStructuralSharing } from "./structural-sharing.js";
 import { assert, type DisableQuery, disableQuery } from "./utils.js";
 
 /**
@@ -167,6 +169,7 @@ export function createUseInfiniteQueryOptions<
     ConnectInfiniteQueryKey<I>,
     MessageInitShape<I>[ParamKey]
   >;
+  structuralSharing?: Exclude<UseQueryOptions["structuralSharing"], undefined>;
   initialPageParam: MessageInitShape<I>[ParamKey];
   enabled: boolean;
 } {
@@ -179,6 +182,7 @@ export function createUseInfiniteQueryOptions<
           [pageParamKey]: undefined,
         },
   );
+  const structuralSharing = createStructuralSharing(methodSig.output);
   return {
     getNextPageParam,
     initialPageParam:
@@ -191,6 +195,7 @@ export function createUseInfiniteQueryOptions<
       callOptions,
       pageParamKey,
     }),
+    structuralSharing,
     enabled: input !== disableQuery,
   };
 }

--- a/packages/connect-query/src/create-use-query-options.ts
+++ b/packages/connect-query/src/create-use-query-options.ts
@@ -28,6 +28,7 @@ import { callUnaryMethod } from "./call-unary-method.js";
 import type { ConnectQueryKey } from "./connect-query-key.js";
 import { createConnectQueryKey } from "./connect-query-key.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
+import { createStructuralSharing } from "./structural-sharing.js";
 import { assert, type DisableQuery, disableQuery } from "./utils.js";
 
 export interface ConnectQueryOptions {
@@ -114,15 +115,18 @@ export function createUseQueryOptions<
 ): {
   queryKey: ConnectQueryKey<I>;
   queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<I>>;
+  structuralSharing?: Exclude<UseQueryOptions["structuralSharing"], undefined>;
   enabled: boolean | undefined;
 } {
   const queryKey = createConnectQueryKey(methodSig, input);
+  const structuralSharing = createStructuralSharing(methodSig.output);
   return {
     queryKey,
     queryFn: createUnaryQueryFn(methodSig, input, {
       transport,
       callOptions,
     }),
+    structuralSharing,
     enabled: input === disableQuery ? false : undefined,
   };
 }

--- a/packages/connect-query/src/structural-sharing.test.ts
+++ b/packages/connect-query/src/structural-sharing.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "@jest/globals";
+
+import { SayRequestSchema, SayResponseSchema } from "./gen/eliza_pb.js";
+import { createStructuralSharing } from "./structural-sharing.js";
+
+describe("structural sharing", () => {
+  const schema = SayResponseSchema;
+  const fn = createStructuralSharing(schema);
+  it("returns old data if equal to old data", () => {
+    const oldData = create(schema, { sentence: "hi" });
+    const newData = create(schema, { sentence: "hi" });
+    const result = fn(oldData, newData);
+    expect(result).toStrictEqual(oldData);
+  });
+  it("returns new data if not equal to old data", () => {
+    const oldData = create(schema, { sentence: "hi" });
+    const newData = create(schema, { sentence: "hello" });
+    const result = fn(oldData, newData);
+    expect(result).toStrictEqual(newData);
+  });
+  it("returns new data if old data is undefined", () => {
+    const oldData = undefined;
+    const newData = create(schema, { sentence: "hello" });
+    const result = fn(oldData, newData);
+    expect(result).toStrictEqual(newData);
+  });
+  it.each([123, null, create(SayRequestSchema, { sentence: "hi" })])(
+    "returns new data for unexpected old data $#",
+    (oldData) => {
+      const newData = create(schema, { sentence: "hi" });
+      const result = fn(oldData, newData);
+      expect(result).toStrictEqual(newData);
+    },
+  );
+  it.each([123, null, create(SayRequestSchema, { sentence: "hi" })])(
+    "returns new data for unexpected new data $#",
+    (newData) => {
+      const oldData = create(schema, { sentence: "hi" });
+      const result = fn(oldData, newData);
+      expect(result).toStrictEqual(newData);
+    },
+  );
+});

--- a/packages/connect-query/src/structural-sharing.ts
+++ b/packages/connect-query/src/structural-sharing.ts
@@ -1,0 +1,39 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { type DescMessage, equals, isMessage } from "@bufbuild/protobuf";
+
+/**
+ * Returns a simplistic implementation for "structural sharing" for a Protobuf
+ * message.
+ *
+ * To keep references intact between re-renders, we return the old version if it
+ * equals the new version.
+ *
+ * See https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations#structural-sharing
+ */
+export function createStructuralSharing(
+  schema: DescMessage,
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- matching the @tanstack/react-query types
+): (oldData: unknown | undefined, newData: unknown) => unknown {
+  return function (oldData, newData) {
+    if (!isMessage(oldData) || !isMessage(newData)) {
+      return newData;
+    }
+    if (!equals(schema, oldData, newData)) {
+      return newData;
+    }
+    return oldData;
+  };
+}


### PR DESCRIPTION
We're supporting [structural sharing](https://tanstack.com/query/latest/docs/framework/react/guides/render-optimizations#structural-sharing) with a basic implementation that returns the old result if the new result is equal.

Fixes https://github.com/connectrpc/connect-query-es/issues/405.