### PR TITLE
V2: Remove option for AbortSignal from useMutation

### DIFF
--- a/packages/connect-query/src/use-mutation.test.ts
+++ b/packages/connect-query/src/use-mutation.test.ts
@@ -13,27 +13,18 @@
 // limitations under the License.
 
 import { create } from "@bufbuild/protobuf";
-import { Code } from "@connectrpc/connect";
 import { describe, expect, it, jest } from "@jest/globals";
 import { renderHook, waitFor } from "@testing-library/react";
 
 import { defaultOptions } from "./default-options.js";
-import { BigIntService } from "./gen/bigint_pb.js";
 import { ListResponseSchema, ListService } from "./gen/list_pb.js";
-import {
-  mockPaginatedTransport,
-  mockStatefulBigIntTransport,
-  wrapper,
-} from "./jest/test-utils.js";
+import { mockPaginatedTransport, wrapper } from "./jest/test-utils.js";
 import { useMutation } from "./use-mutation.js";
 
 // TODO: maybe create a helper to take a service and method and generate this.
 const methodDescriptor = ListService.method.list;
 
 const mockedPaginatedTransport = mockPaginatedTransport();
-const mutationTransport = mockStatefulBigIntTransport(true);
-
-const statefulDescriptor = BigIntService.method.count;
 
 describe("useMutation", () => {
   it("performs a mutation", async () => {
@@ -99,49 +90,6 @@ describe("useMutation", () => {
     });
 
     expect(result.current.data?.items[0]).toBe("Intercepted!");
-  });
-
-  it("can be cancelled", async () => {
-    const abortController = new AbortController();
-    const { result } = renderHook(
-      () => {
-        return useMutation(statefulDescriptor, {
-          callOptions: {
-            signal: abortController.signal,
-          },
-        });
-      },
-      wrapper(
-        {
-          defaultOptions,
-        },
-        mutationTransport,
-      ),
-    );
-
-    result.current.mutate({
-      add: 1n,
-    });
-
-    abortController.abort();
-
-    await waitFor(() => {
-      expect(abortController.signal.aborted).toBeTruthy();
-    });
-
-    expect(result.current.isPending).toBeFalsy();
-    expect(result.current.isError).toBeTruthy();
-    expect(result.current.error?.code).toBe(Code.Canceled);
-
-    const newResult = await mutationTransport.unary(
-      BigIntService.method.getCount,
-      undefined,
-      undefined,
-      undefined,
-      {},
-    );
-
-    expect(newResult.message.count).toBe(0n);
   });
 
   it("can forward onMutate params", async () => {

--- a/packages/connect-query/src/use-mutation.ts
+++ b/packages/connect-query/src/use-mutation.ts
@@ -29,7 +29,7 @@ import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { useTransport } from "./use-transport.js";
 
 /**
- * Options for useQuery
+ * Options for useMutation
  */
 export type UseMutationOptions<
   I extends DescMessage,
@@ -40,7 +40,7 @@ export type UseMutationOptions<
   "mutationFn"
 > & {
   transport?: Transport;
-  callOptions?: CallOptions;
+  callOptions?: Omit<CallOptions, "signal">;
 };
 
 /**
@@ -68,7 +68,7 @@ export function useMutation<
     async (input: MessageInitShape<I>) => {
       const result = await transportToUse.unary(
         schema,
-        callOptions?.signal,
+        undefined,
         callOptions?.timeoutMs,
         callOptions?.headers,
         input,


### PR DESCRIPTION
I noticed that `useMutation` accepts `CallOptions.signal`, but other hooks do not. This removes the option. 

I'm not sure why it would be desirable to cancel a mutation. If I'm missing something, please let me know.