### PR TITLE
Remove outdated JSDoc tags

### DIFF
--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -35,9 +35,6 @@ import type { DisableQuery } from "./utils.js";
 
 /**
  * Query the method provided. Maps to useInfiniteQuery on tanstack/react-query
- *
- * @param methodSig
- * @returns
  */
 export function useInfiniteQuery<
   I extends Message<I>,
@@ -73,9 +70,6 @@ export function useInfiniteQuery<
 
 /**
  * Query the method provided. Maps to useSuspenseInfiniteQuery on tanstack/react-query
- *
- * @param methodSig
- * @returns
  */
 export function useSuspenseInfiniteQuery<
   I extends Message<I>,

--- a/packages/connect-query/src/use-mutation.ts
+++ b/packages/connect-query/src/use-mutation.ts
@@ -41,9 +41,6 @@ export type UseMutationOptions<
 
 /**
  * Query the method provided. Maps to useMutation on tanstack/react-query
- *
- * @param methodSig
- * @returns
  */
 export function useMutation<
   I extends Message<I>,

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -34,9 +34,6 @@ import type { DisableQuery } from "./utils.js";
 
 /**
  * Query the method provided. Maps to useQuery on tanstack/react-query
- *
- * @param methodSig
- * @returns
  */
 export function useQuery<
   I extends Message<I>,
@@ -74,9 +71,6 @@ export function useQuery<
 
 /**
  * Query the method provided. Maps to useSuspenseQuery on tanstack/react-query
- *
- * @param methodSig
- * @returns
  */
 export function useSuspenseQuery<
   I extends Message<I>,


### PR DESCRIPTION
Parts of the API use JSDoc tags, but they are all outdated. That's worse than having no tags, so I propose we remove them.