### PR TITLE
Honor all call options in callUnaryMethod

### DIFF
--- a/packages/connect-query/src/call-unary-method.ts
+++ b/packages/connect-query/src/call-unary-method.ts
@@ -18,7 +18,7 @@ import type { CallOptions, Transport } from "@connectrpc/connect";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 
 /**
- * Call a unary method given it's signature and input.
+ * Call a unary method given its signature and input.
  */
 export async function callUnaryMethod<
   I extends Message<I>,
@@ -41,6 +41,9 @@ export async function callUnaryMethod<
     callOptions?.timeoutMs,
     callOptions?.headers,
     input ?? {},
+    callOptions?.contextValues,
   );
+  callOptions?.onHeader?.(result.header);
+  callOptions?.onTrailer?.(result.trailer);
   return result.message;
 }

--- a/packages/connect-query/src/use-mutation.ts
+++ b/packages/connect-query/src/use-mutation.ts
@@ -21,6 +21,7 @@ import type {
 import { useMutation as tsUseMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
 
+import { callUnaryMethod } from "./call-unary-method.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { useTransport } from "./use-transport.js";
 
@@ -58,17 +59,11 @@ export function useMutation<
   const transportFromCtx = useTransport();
   const transportToUse = transport ?? transportFromCtx;
   const mutationFn = useCallback(
-    async (input: PartialMessage<I>) => {
-      const result = await transportToUse.unary(
-        { typeName: methodSig.service.typeName, methods: {} },
-        methodSig,
-        callOptions?.signal,
-        callOptions?.timeoutMs,
-        callOptions?.headers,
-        input,
-      );
-      return result.message;
-    },
+    async (input: PartialMessage<I>) =>
+      callUnaryMethod(methodSig, input, {
+        transport: transportToUse,
+        callOptions,
+      }),
     [transportToUse, callOptions, methodSig],
   );
   return tsUseMutation({


### PR DESCRIPTION
`callUnaryMethod` accepts `CallOptions` from `@connectrpc/connect`. This updates the implementation to support all options.