### PR TITLE
V2: Support disabled queries consistently

### DIFF
--- a/packages/connect-query/src/create-use-infinite-query-options.ts
+++ b/packages/connect-query/src/create-use-infinite-query-options.ts
@@ -171,7 +171,7 @@ export function createUseInfiniteQueryOptions<
   >;
   structuralSharing?: Exclude<UseQueryOptions["structuralSharing"], undefined>;
   initialPageParam: MessageInitShape<I>[ParamKey];
-  enabled: boolean;
+  enabled?: false;
 } {
   const queryKey = createConnectInfiniteQueryKey(
     schema,
@@ -196,6 +196,6 @@ export function createUseInfiniteQueryOptions<
       pageParamKey,
     }),
     structuralSharing,
-    enabled: input !== disableQuery,
+    ...(input === disableQuery ? { enabled: false } : undefined),
   };
 }

--- a/packages/connect-query/src/create-use-query-options.ts
+++ b/packages/connect-query/src/create-use-query-options.ts
@@ -116,7 +116,7 @@ export function createUseQueryOptions<
   queryKey: ConnectQueryKey<I>;
   queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<I>>;
   structuralSharing?: Exclude<UseQueryOptions["structuralSharing"], undefined>;
-  enabled: boolean | undefined;
+  enabled?: false;
 } {
   const queryKey = createConnectQueryKey(schema, input);
   const structuralSharing = createStructuralSharing(schema.output);
@@ -127,6 +127,6 @@ export function createUseQueryOptions<
       callOptions,
     }),
     structuralSharing,
-    enabled: input === disableQuery ? false : undefined,
+    ...(input === disableQuery ? { enabled: false } : undefined),
   };
 }

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -54,7 +54,7 @@ export function useInfiniteQuery<
     callOptions,
     pageParamKey,
     getNextPageParam,
-    ...options
+    ...queryOptions
   }: Omit<CreateInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
     transport?: Transport;
   },
@@ -66,10 +66,10 @@ export function useInfiniteQuery<
     pageParamKey,
     callOptions,
   });
-  // The query cannot be enabled if the base options are disabled, regardless of
-  // incoming query options.
-  const enabled = baseOptions.enabled && (options.enabled ?? true);
-  return tsUseInfiniteQuery({ ...options, ...baseOptions, enabled });
+  return tsUseInfiniteQuery({
+    ...queryOptions,
+    ...baseOptions,
+  });
 }
 
 /**
@@ -87,7 +87,7 @@ export function useSuspenseInfiniteQuery<
     callOptions,
     pageParamKey,
     getNextPageParam,
-    ...options
+    ...queryOptions
   }: Omit<CreateSuspenseInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
     transport?: Transport;
   },
@@ -99,6 +99,8 @@ export function useSuspenseInfiniteQuery<
     pageParamKey,
     callOptions,
   });
-
-  return tsUseSuspenseInfiniteQuery({ ...options, ...baseOptions });
+  return tsUseSuspenseInfiniteQuery({
+    ...queryOptions,
+    ...baseOptions,
+  });
 }

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -59,18 +59,10 @@ export function useQuery<
     transport: transport ?? transportFromCtx,
     callOptions,
   });
-  const { enabled: baseEnabled, ...baseRest } = baseOptions;
-  const tsOpts = {
+  return tsUseQuery({
     ...queryOptions,
-    ...baseRest,
-  };
-  // The query cannot be enabled if the base options are disabled, regardless of
-  // incoming query options.
-  const enabled = baseEnabled ?? queryOptions.enabled;
-  if (enabled !== undefined) {
-    tsOpts.enabled = enabled;
-  }
-  return tsUseQuery(tsOpts);
+    ...baseOptions,
+  });
 }
 
 /**


### PR DESCRIPTION
https://github.com/connectrpc/connect-query-es/pull/369 made a change to `useQuery` to support edge cases with the `enabled` option.

This makes the same change to the other query hooks.