### PR TITLE
V2: Remove CallOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Connect-Query is an wrapper around [TanStack Query](https://tanstack.com/query) 
   - [`createConnectQueryKey`](#createconnectquerykey)
   - [`callUnaryMethod`](#callunarymethod)
   - [`createProtobufSafeUpdater`](#createprotobufsafeupdater)
-  - [`createUseQueryOptions`](#createusequeryoptions)
-  - [`createUseInfiniteQueryOptions`](#createuseinfinitequeryoptions)
+  - [`createQueryOptions`](#createqueryoptions)
+  - [`createInfiniteQueryOptions`](#createinfinitequeryoptions)
   - [`ConnectQueryKey`](#connectquerykey)
 
 ## Quickstart
@@ -316,10 +316,10 @@ queryClient.setQueryData(
 
 ```
 
-### `createUseQueryOptions`
+### `createQueryOptions`
 
 ```ts
-function createUseQueryOptions<I extends DescMessage, O extends DescMessage>(
+function createQueryOptions<I extends DescMessage, O extends DescMessage>(
   schema: MethodUnaryDescriptor<I, O>,
   input: SkipToken | PartialMessage<I> | undefined,
   {
@@ -340,23 +340,23 @@ An example of how to use this function with `useQueries`:
 
 ```ts
 import { useQueries } from "@tanstack/react-query";
-import { createUseQueryOptions, useTransport } from "@connectrpc/connect-query";
+import { createQueryOptions, useTransport } from "@connectrpc/connect-query";
 import { example } from "your-generated-code/example-ExampleService_connectquery";
 
 const MyComponent = () => {
   const transport = useTransport();
   const [query1, query2] = useQueries([
-    createUseQueryOptions(example, { sentence: "First query" }, { transport }),
-    createUseQueryOptions(example, { sentence: "Second query" }, { transport }),
+    createQueryOptions(example, { sentence: "First query" }, { transport }),
+    createQueryOptions(example, { sentence: "Second query" }, { transport }),
   ]);
   ...
 };
 ```
 
-### `createUseInfiniteQueryOptions`
+### `createInfiniteQueryOptions`
 
 ```ts
-function createUseInfiniteQueryOptions<
+function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends keyof MessageInitShape<I>,

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Connect-Query is an wrapper around [TanStack Query](https://tanstack.com/query) 
   - [`createConnectQueryKey`](#createconnectquerykey)
   - [`callUnaryMethod`](#callunarymethod)
   - [`createProtobufSafeUpdater`](#createprotobufsafeupdater)
-  - [`createQueryOptions`](#createqueryoptions)
-  - [`createInfiniteQueryOptions`](#createinfinitequeryoptions)
+  - [`createUseQueryOptions`](#createusequeryoptions)
+  - [`createUseInfiniteQueryOptions`](#createuseinfinitequeryoptions)
   - [`ConnectQueryKey`](#connectquerykey)
 
 ## Quickstart
@@ -189,14 +189,16 @@ Use this helper to get the default transport that's currently attached to the Re
 ### `useQuery`
 
 ```ts
-function useQuery<I extends Message<I>, O extends Message<O>>(
-  methodSig: MethodUnaryDescriptor<I, O>,
-  input?: SkipToken | PartialMessage<I>,
-  options?: {
+function useQuery<I extends DescMessage, O extends DescMessage, SelectOutData = MessageShape<O>>(
+  schema: MethodUnaryDescriptor<I, O>,
+  input?: SkipToken | MessageInitShape<I>,
+  {
+    transport,
+    ...queryOptions
+  }: Omit<CreateQueryOptions<I, O, SelectOutData>, "transport"> & {
     transport?: Transport;
-    callOptions?: CallOptions;
-  } & UseQueryOptions,
-): UseQueryResult<O, ConnectError>;
+  } = {},
+): UseQueryResult<SelectOutData, ConnectError>;
 ```
 
 The `useQuery` hook is the primary way to make a unary request. It's a wrapper around TanStack Query's [`useQuery`](https://tanstack.com/query/v5/docs/react/reference/useQuery) hook, but it's preconfigured with the correct `queryKey` and `queryFn` for the given method.
@@ -211,20 +213,23 @@ Identical to useQuery but mapping to the `useSuspenseQuery` hook from [TanStack 
 
 ```ts
 function useInfiniteQuery<
-  I extends Message<I>,
-  O extends Message<O>,
-  ParamKey extends keyof PartialMessage<I>,
-  Input extends PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
 >(
-  methodSig: MethodUnaryDescriptor<I, O>,
-  input: SkipToken | Input,
-  options: {
-    pageParamKey: ParamKey;
+  schema: MethodUnaryDescriptor<I, O>,
+  input:
+    | SkipToken
+    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+  {
+    transport,
+    pageParamKey,
+    getNextPageParam,
+    ...queryOptions
+  }: Omit<CreateInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
     transport?: Transport;
-    callOptions?: CallOptions;
-    getNextPageParam: GetNextPageParamFunction<PartialMessage<I>[ParamKey], O>;
   },
-): UseInfiniteQueryResult<InfiniteData<O>, ConnectError>;
+): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError>;
 ```
 
 The `useInfiniteQuery` is a wrapper around TanStack Query's [`useInfiniteQuery`](https://tanstack.com/query/v5/docs/react/reference/useInfiniteQuery) hook, but it's preconfigured with the correct `queryKey` and `queryFn` for the given method.
@@ -238,13 +243,10 @@ Identical to useInfiniteQuery but mapping to the `useSuspenseInfiniteQuery` hook
 ### `useMutation`
 
 ```ts
-function useMutation<I extends Message<I>, O extends Message<O>>(
-  methodSig: MethodUnaryDescriptor<I, O>,
-  options?: {
-    transport?: Transport;,
-    callOptions?: CallOptions;
-  },
-): UseMutationResult<O, ConnectError, PartialMessage<I>>
+function useMutation<I extends DescMessage, O extends DescMessage>(
+  schema: MethodUnaryDescriptor<I, O>,
+  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {},
+): UseMutationResult<MessageShape<O>, ConnectError, PartialMessage<I>>
 ```
 
 The `useMutation` is a wrapper around TanStack Query's [`useMutation`](https://tanstack.com/query/v5/docs/react/reference/useMutation) hook, but it's preconfigured with the correct `mutationFn` for the given method.
@@ -280,15 +282,12 @@ This function is not really necessary unless you are manually creating infinite 
 ### `callUnaryMethod`
 
 ```ts
-function callUnaryMethod<I extends Message<I>, O extends Message<O>>(
-  methodType: MethodUnaryDescriptor<I, O>,
-  input: PartialMessage<I> | undefined,
-  {
-    callOptions,
-    transport,
-  }: {
-    transport: Transport;
-    callOptions?: CallOptions | undefined;
+function callUnaryMethod<I extends DescMessage, O extends DescMessage>(
+  transport: Transport,
+  schema: MethodUnaryDescriptor<I, O>,
+  input: MessageInitShape<I> | undefined,
+  options?: {
+    signal?: AbortSignal;
   },
 ): Promise<O>;
 ```
@@ -317,60 +316,59 @@ queryClient.setQueryData(
 
 ```
 
-### `createQueryOptions`
+### `createUseQueryOptions`
 
 ```ts
-function createQueryOptions<I extends Message<I>, O extends Message<O>>(
-  methodSig: MethodUnaryDescriptor<I, O>,
+function createUseQueryOptions<I extends DescMessage, O extends DescMessage>(
+  schema: MethodUnaryDescriptor<I, O>,
   input: SkipToken | PartialMessage<I> | undefined,
   {
     transport,
-    callOptions,
-  }: ConnectQueryOptions & {
+  }: {
     transport: Transport;
   },
 ): {
   queryKey: ConnectQueryKey<I>;
-  queryFn: QueryFunction<O, ConnectQueryKey<I>>;
-  enabled: boolean;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<I>> | SkipToken;
+  structuralSharing: Exclude<UseQueryOptions["structuralSharing"], undefined>;
 };
 ```
 
-A functional version of the options that can be passed to the `useQuery` hook from `@tanstack/react-query`. When called, it will return the appropriate `queryKey`, `queryFn`, and `enabled` flag. This is useful when interacting with `useQueries` API or queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
+A functional version of the options that can be passed to the `useQuery` hook from `@tanstack/react-query`. When called, it will return the appropriate `queryKey`, `queryFn`, and `structuralSharing` flag. This is useful when interacting with `useQueries` API or queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
 
 An example of how to use this function with `useQueries`:
 
 ```ts
 import { useQueries } from "@tanstack/react-query";
-import { createQueryOptions, useTransport } from "@connectrpc/connect-query";
+import { createUseQueryOptions, useTransport } from "@connectrpc/connect-query";
 import { example } from "your-generated-code/example-ExampleService_connectquery";
 
 const MyComponent = () => {
   const transport = useTransport();
   const [query1, query2] = useQueries([
-    createQueryOptions(example, { sentence: "First query" }, { transport }),
-    createQueryOptions(example, { sentence: "Second query" }, { transport }),
+    createUseQueryOptions(example, { sentence: "First query" }, { transport }),
+    createUseQueryOptions(example, { sentence: "Second query" }, { transport }),
   ]);
   ...
 };
 ```
 
-### `createInfiniteQueryOptions`
+### `createUseInfiniteQueryOptions`
 
 ```ts
-function createInfiniteQueryOptions<
-  I extends Message<I>,
-  O extends Message<O>,
-  ParamKey extends keyof PartialMessage<I>,
-  Input extends PartialMessage<I> & Required<Pick<PartialMessage<I>, ParamKey>>,
+function createUseInfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
 >(
-  methodSig: MethodUnaryDescriptor<I, O>,
-  input: SkipToken | Input,
+  schema: MethodUnaryDescriptor<I, O>,
+  input:
+    | SkipToken
+    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
   {
     transport,
     getNextPageParam,
     pageParamKey,
-    callOptions,
   }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
@@ -379,17 +377,19 @@ function createInfiniteQueryOptions<
     ParamKey
   >["getNextPageParam"];
   queryKey: ConnectInfiniteQueryKey<I>;
-  queryFn: QueryFunction<
-    O,
+  queryFn:
+    | QueryFunction<
+    MessageShape<O>,
     ConnectInfiniteQueryKey<I>,
-    PartialMessage<I>[ParamKey]
-  >;
+    MessageInitShape<I>[ParamKey]
+  >
+    | SkipToken;
+  structuralSharing: Exclude<UseQueryOptions["structuralSharing"], undefined>;
   initialPageParam: PartialMessage<I>[ParamKey];
-  enabled: boolean;
 };
 ```
 
-A functional version of the options that can be passed to the `useInfiniteQuery` hook from `@tanstack/react-query`.When called, it will return the appropriate `queryKey`, `queryFn`, and `enabled` flags, as well as a few other parameters required for `useInfiniteQuery`. This is useful when interacting with some queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
+A functional version of the options that can be passed to the `useInfiniteQuery` hook from `@tanstack/react-query`.When called, it will return the appropriate `queryKey`, `queryFn`, and `structuralSharing` flags, as well as a few other parameters required for `useInfiniteQuery`. This is useful when interacting with some queryClient methods (like [ensureQueryData](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata), etc).
 
 ### `ConnectQueryKey`
 
@@ -534,7 +534,7 @@ function prefetch() {
   return queryClient.prefetchQuery({
     queryKey: createConnectQueryKey(say, { sentence: "Hello" }),
     queryFn: () =>
-      callUnaryMethod(say, { sentence: "Hello" }, { transport: myTransport }),
+      callUnaryMethod(myTransport, say, { sentence: "Hello" }),
   });
 }
 ```

--- a/packages/connect-query/src/call-unary-method.test.ts
+++ b/packages/connect-query/src/call-unary-method.test.ts
@@ -41,16 +41,15 @@ describe("callUnaryMethod", () => {
               }: QueryFunctionContext<
                 ConnectQueryKey<typeof SayRequestSchema>
               >) => {
+                const transport = mockEliza({
+                  sentence: "Response 1",
+                });
                 const res = await callUnaryMethod(
+                  transport,
                   ElizaService.method.say,
                   queryKey[2],
                   {
-                    transport: mockEliza({
-                      sentence: "Response 1",
-                    }),
-                    callOptions: {
-                      signal,
-                    },
+                    signal,
                   },
                 );
                 return res;

--- a/packages/connect-query/src/call-unary-method.ts
+++ b/packages/connect-query/src/call-unary-method.ts
@@ -18,36 +18,32 @@ import type {
   MessageShape,
 } from "@bufbuild/protobuf";
 import { create } from "@bufbuild/protobuf";
-import type { CallOptions, Transport } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
 
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 
 /**
  * Call a unary method given its signature and input.
  */
+// eslint-disable-next-line @typescript-eslint/max-params -- 4th param is optional
 export async function callUnaryMethod<
   I extends DescMessage,
   O extends DescMessage,
 >(
+  transport: Transport,
   schema: MethodUnaryDescriptor<I, O>,
   input: MessageInitShape<I> | undefined,
-  {
-    callOptions,
-    transport,
-  }: {
-    transport: Transport;
-    callOptions?: CallOptions | undefined;
+  options?: {
+    signal?: AbortSignal;
   },
 ): Promise<MessageShape<O>> {
   const result = await transport.unary(
     schema,
-    callOptions?.signal,
-    callOptions?.timeoutMs,
-    callOptions?.headers,
+    options?.signal,
+    undefined,
+    undefined,
     input ?? create(schema.input),
-    callOptions?.contextValues,
+    undefined,
   );
-  callOptions?.onHeader?.(result.header);
-  callOptions?.onTrailer?.(result.trailer);
   return result.message;
 }

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -51,7 +51,6 @@ export function useInfiniteQuery<
     | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
   {
     transport,
-    callOptions,
     pageParamKey,
     getNextPageParam,
     ...queryOptions
@@ -64,7 +63,6 @@ export function useInfiniteQuery<
     transport: transport ?? transportFromCtx,
     getNextPageParam,
     pageParamKey,
-    callOptions,
   });
   return tsUseInfiniteQuery({
     ...baseOptions,
@@ -84,7 +82,6 @@ export function useSuspenseInfiniteQuery<
   input: MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>,
   {
     transport,
-    callOptions,
     pageParamKey,
     getNextPageParam,
     ...queryOptions
@@ -97,7 +94,6 @@ export function useSuspenseInfiniteQuery<
     transport: transport ?? transportFromCtx,
     getNextPageParam,
     pageParamKey,
-    callOptions,
   });
   return tsUseSuspenseInfiniteQuery({
     ...baseOptions,

--- a/packages/connect-query/src/use-mutation.ts
+++ b/packages/connect-query/src/use-mutation.ts
@@ -17,7 +17,7 @@ import type {
   MessageInitShape,
   MessageShape,
 } from "@bufbuild/protobuf";
-import type { CallOptions, ConnectError, Transport } from "@connectrpc/connect";
+import type { ConnectError, Transport } from "@connectrpc/connect";
 import type {
   UseMutationOptions as TSUseMutationOptions,
   UseMutationResult,
@@ -42,8 +42,8 @@ export type UseMutationOptions<
   MessageInitShape<I>,
   Ctx
 > & {
+  /** The transport to be used for the fetching. */
   transport?: Transport;
-  callOptions?: Omit<CallOptions, "signal">;
 };
 
 /**
@@ -55,22 +55,14 @@ export function useMutation<
   Ctx = unknown,
 >(
   schema: MethodUnaryDescriptor<I, O>,
-  // istanbul ignore next
-  {
-    transport,
-    callOptions,
-    ...queryOptions
-  }: UseMutationOptions<I, O, Ctx> = {},
+  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {},
 ): UseMutationResult<MessageShape<O>, ConnectError, MessageInitShape<I>, Ctx> {
   const transportFromCtx = useTransport();
   const transportToUse = transport ?? transportFromCtx;
   const mutationFn = useCallback(
     async (input: MessageInitShape<I>) =>
-      callUnaryMethod(schema, input, {
-        transport: transportToUse,
-        callOptions,
-      }),
-    [transportToUse, callOptions, schema],
+      callUnaryMethod(transportToUse, schema, input),
+    [transportToUse, schema],
   );
   return tsUseMutation({
     ...queryOptions,

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -48,7 +48,6 @@ export function useQuery<
   input?: SkipToken | MessageInitShape<I>,
   {
     transport,
-    callOptions,
     ...queryOptions
   }: Omit<CreateQueryOptions<I, O, SelectOutData>, "transport"> & {
     transport?: Transport;
@@ -57,7 +56,6 @@ export function useQuery<
   const transportFromCtx = useTransport();
   const baseOptions = createUseQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
-    callOptions,
   });
   return tsUseQuery({
     ...baseOptions,
@@ -77,7 +75,6 @@ export function useSuspenseQuery<
   input?: MessageInitShape<I>,
   {
     transport,
-    callOptions,
     ...queryOptions
   }: Omit<CreateSuspenseQueryOptions<I, O, SelectOutData>, "transport"> & {
     transport?: Transport;
@@ -86,7 +83,6 @@ export function useSuspenseQuery<
   const transportFromCtx = useTransport();
   const baseOptions = createUseQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
-    callOptions,
   });
   return tsUseSuspenseQuery({
     ...baseOptions,


### PR DESCRIPTION
Hooks and several other functions accept [`CallOptions`](https://github.com/connectrpc/connect-es/blob/v1.5.0/packages/connect/src/call-options.ts#L21) from `@connectrpc/connect`. In general, every Connect client should accept a call options argument, but they don't work well with TanStack Query's caching. 

For now, we're removing `CallOptions` from the function arguments in v2. 