### PR TITLE
V2: Introduce function to create transport keys

### DIFF
--- a/packages/connect-query/src/transport-key.test.ts
+++ b/packages/connect-query/src/transport-key.test.ts
@@ -1,0 +1,40 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { describe, expect, it } from "vitest";
+
+import { createTransportKey } from "./transport-key.js";
+
+describe("transport key", () => {
+  it("returns the same key for the same reference", () => {
+    const transport = createConnectTransport({
+      baseUrl: "https://example.com",
+    });
+    const key1 = createTransportKey(transport);
+    const key2 = createTransportKey(transport);
+    expect(key1).toBe(key2);
+  });
+  it("creates a unique key for every reference", () => {
+    const transport1 = createConnectTransport({
+      baseUrl: "https://example.com",
+    });
+    const transport2 = createConnectTransport({
+      baseUrl: "https://example.com",
+    });
+    const key1 = createTransportKey(transport1);
+    const key2 = createTransportKey(transport2);
+    expect(key1).not.toBe(key2);
+  });
+});

--- a/packages/connect-query/src/transport-key.ts
+++ b/packages/connect-query/src/transport-key.ts
@@ -1,0 +1,33 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Transport } from "@connectrpc/connect";
+
+const transportKeys = new WeakMap<Transport, string>();
+let counter = 0;
+
+/**
+ * For a given Transport, create a string key that is suitable for a Query Key
+ * in TanStack Query.
+ *
+ * This function will return a unique string for every reference.
+ */
+export function createTransportKey(transport: Transport): string {
+  let key = transportKeys.get(transport);
+  if (key === undefined) {
+    key = `t${++counter}`;
+    transportKeys.set(transport, key);
+  }
+  return key;
+}


### PR DESCRIPTION
As a potential solution for #418, this introduces a function to create a unique key per Transport reference. 

Going forward, we can use this function to create query keys that include the Transport.