### PR TITLE
V2: Rename symbols to match exported names

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,7 @@ Use this helper to get the default transport that's currently attached to the Re
 function useQuery<I extends DescMessage, O extends DescMessage, SelectOutData = MessageShape<O>>(
   schema: MethodUnaryDescriptor<I, O>,
   input?: SkipToken | MessageInitShape<I>,
-  {
-    transport,
-    ...queryOptions
-  }: Omit<CreateQueryOptions<I, O, SelectOutData>, "transport"> & {
-    transport?: Transport;
-  } = {},
+  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {},
 ): UseQueryResult<SelectOutData, ConnectError>;
 ```
 

--- a/README.md
+++ b/README.md
@@ -221,9 +221,7 @@ function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: Omit<CreateInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
-    transport?: Transport;
-  },
+  }: UseInfiniteQueryOptions<I, O, ParamKey>,
 ): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError>;
 ```
 

--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -45,8 +45,6 @@ export interface ConnectInfiniteQueryOptions<
 > {
   /** Defines which part of the input should be considered the page param */
   pageParamKey: ParamKey;
-  /** Transport can be overridden here.*/
-  transport: Transport;
   /** Determines the next page. */
   getNextPageParam: GetNextPageParamFunction<
     MessageInitShape<I>[ParamKey],
@@ -102,7 +100,7 @@ export function createInfiniteQueryOptions<
     transport,
     getNextPageParam,
     pageParamKey,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,

--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -17,15 +17,12 @@ import type {
   MessageInitShape,
   MessageShape,
 } from "@bufbuild/protobuf";
-import type { ConnectError, Transport } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
 import type {
   GetNextPageParamFunction,
-  InfiniteData,
   QueryFunction,
   SkipToken,
-  UseInfiniteQueryOptions as TanStackUseInfiniteQueryOptions,
   UseQueryOptions,
-  UseSuspenseInfiniteQueryOptions as TanStackUseSuspenseInfiniteQueryOptions,
 } from "@tanstack/react-query";
 import { skipToken } from "@tanstack/react-query";
 
@@ -56,46 +53,6 @@ export interface ConnectInfiniteQueryOptions<
     MessageShape<O>
   >;
 }
-
-/**
- * Options for useInfiniteQuery
- */
-export type UseInfiniteQueryOptions<
-  I extends DescMessage,
-  O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
-> = ConnectInfiniteQueryOptions<I, O, ParamKey> &
-  Omit<
-    TanStackUseInfiniteQueryOptions<
-      MessageShape<O>,
-      ConnectError,
-      InfiniteData<MessageShape<O>>,
-      MessageShape<O>,
-      ConnectInfiniteQueryKey<I>,
-      MessageInitShape<I>[ParamKey]
-    >,
-    "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
-  >;
-
-/**
- * Options for useSuspenseInfiniteQuery
- */
-export type UseSuspenseInfiniteQueryOptions<
-  I extends DescMessage,
-  O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
-> = ConnectInfiniteQueryOptions<I, O, ParamKey> &
-  Omit<
-    TanStackUseSuspenseInfiniteQueryOptions<
-      MessageShape<O>,
-      ConnectError,
-      InfiniteData<MessageShape<O>>,
-      MessageShape<O>,
-      ConnectInfiniteQueryKey<I>,
-      MessageInitShape<I>[ParamKey]
-    >,
-    "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
-  >;
 
 // eslint-disable-next-line @typescript-eslint/max-params -- we have 4 required arguments
 function createUnaryInfiniteQueryFn<

--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -23,9 +23,9 @@ import type {
   InfiniteData,
   QueryFunction,
   SkipToken,
-  UseInfiniteQueryOptions,
+  UseInfiniteQueryOptions as TanStackUseInfiniteQueryOptions,
   UseQueryOptions,
-  UseSuspenseInfiniteQueryOptions,
+  UseSuspenseInfiniteQueryOptions as TanStackUseSuspenseInfiniteQueryOptions,
 } from "@tanstack/react-query";
 import { skipToken } from "@tanstack/react-query";
 
@@ -60,13 +60,13 @@ export interface ConnectInfiniteQueryOptions<
 /**
  * Options for useInfiniteQuery
  */
-export type CreateInfiniteQueryOptions<
+export type UseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends keyof MessageInitShape<I>,
 > = ConnectInfiniteQueryOptions<I, O, ParamKey> &
   Omit<
-    UseInfiniteQueryOptions<
+    TanStackUseInfiniteQueryOptions<
       MessageShape<O>,
       ConnectError,
       InfiniteData<MessageShape<O>>,
@@ -80,13 +80,13 @@ export type CreateInfiniteQueryOptions<
 /**
  * Options for useSuspenseInfiniteQuery
  */
-export type CreateSuspenseInfiniteQueryOptions<
+export type UseSuspenseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends keyof MessageInitShape<I>,
 > = ConnectInfiniteQueryOptions<I, O, ParamKey> &
   Omit<
-    UseSuspenseInfiniteQueryOptions<
+    TanStackUseSuspenseInfiniteQueryOptions<
       MessageShape<O>,
       ConnectError,
       InfiniteData<MessageShape<O>>,
@@ -132,7 +132,7 @@ function createUnaryInfiniteQueryFn<
 /**
  * Query the method provided. Maps to useInfiniteQuery on tanstack/react-query
  */
-export function createUseInfiniteQueryOptions<
+export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends keyof MessageInitShape<I>,

--- a/packages/connect-query/src/create-query-options.test.ts
+++ b/packages/connect-query/src/create-query-options.test.ts
@@ -16,7 +16,7 @@ import { skipToken } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
 
 import { createConnectQueryKey } from "./connect-query-key.js";
-import { createUseQueryOptions } from "./create-use-query-options.js";
+import { createQueryOptions } from "./create-query-options.js";
 import { ElizaService } from "./gen/eliza_pb.js";
 import { mockEliza } from "./test/test-utils.js";
 
@@ -27,14 +27,14 @@ const mockedElizaTransport = mockEliza();
 
 describe("createUseQueryOptions", () => {
   it("honors skipToken", () => {
-    const opt = createUseQueryOptions(sayMethodDescriptor, skipToken, {
+    const opt = createQueryOptions(sayMethodDescriptor, skipToken, {
       transport: mockedElizaTransport,
     });
     expect(opt.queryFn).toBe(skipToken);
   });
   it("sets queryKey", () => {
     const want = createConnectQueryKey(sayMethodDescriptor, { sentence: "hi" });
-    const opt = createUseQueryOptions(
+    const opt = createQueryOptions(
       sayMethodDescriptor,
       { sentence: "hi" },
       {

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -17,12 +17,11 @@ import type {
   MessageInitShape,
   MessageShape,
 } from "@bufbuild/protobuf";
-import type { ConnectError, Transport } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
 import type {
   QueryFunction,
   SkipToken,
   UseQueryOptions as TanStackUseQueryOptions,
-  UseSuspenseQueryOptions as TanStackUseSuspenseQueryOptions,
 } from "@tanstack/react-query";
 import { skipToken } from "@tanstack/react-query";
 
@@ -31,46 +30,6 @@ import type { ConnectQueryKey } from "./connect-query-key.js";
 import { createConnectQueryKey } from "./connect-query-key.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { createStructuralSharing } from "./structural-sharing.js";
-
-/**
- * Options for useQuery
- */
-export type UseQueryOptions<
-  I extends DescMessage,
-  O extends DescMessage,
-  SelectOutData = MessageShape<O>,
-> = Omit<
-  TanStackUseQueryOptions<
-    MessageShape<O>,
-    ConnectError,
-    SelectOutData,
-    ConnectQueryKey<I>
-  >,
-  "queryFn" | "queryKey"
-> & {
-  /** The transport to be used for the fetching. */
-  transport: Transport;
-};
-
-/**
- * Options for useSuspenseQuery
- */
-export type UseSuspenseQueryOptions<
-  I extends DescMessage,
-  O extends DescMessage,
-  SelectOutData = 0,
-> = Omit<
-  TanStackUseSuspenseQueryOptions<
-    MessageShape<O>,
-    ConnectError,
-    SelectOutData,
-    ConnectQueryKey<I>
-  >,
-  "queryFn" | "queryKey"
-> & {
-  /** The transport to be used for the fetching. */
-  transport: Transport;
-};
 
 function createUnaryQueryFn<I extends DescMessage, O extends DescMessage>(
   transport: Transport,

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -21,8 +21,8 @@ import type { ConnectError, Transport } from "@connectrpc/connect";
 import type {
   QueryFunction,
   SkipToken,
-  UseQueryOptions,
-  UseSuspenseQueryOptions,
+  UseQueryOptions as TanStackUseQueryOptions,
+  UseSuspenseQueryOptions as TanStackUseSuspenseQueryOptions,
 } from "@tanstack/react-query";
 import { skipToken } from "@tanstack/react-query";
 
@@ -35,12 +35,12 @@ import { createStructuralSharing } from "./structural-sharing.js";
 /**
  * Options for useQuery
  */
-export type CreateQueryOptions<
+export type UseQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   SelectOutData = MessageShape<O>,
 > = Omit<
-  UseQueryOptions<
+  TanStackUseQueryOptions<
     MessageShape<O>,
     ConnectError,
     SelectOutData,
@@ -60,7 +60,7 @@ export type CreateSuspenseQueryOptions<
   O extends DescMessage,
   SelectOutData = 0,
 > = Omit<
-  UseSuspenseQueryOptions<
+  TanStackUseSuspenseQueryOptions<
     MessageShape<O>,
     ConnectError,
     SelectOutData,
@@ -87,7 +87,7 @@ function createUnaryQueryFn<I extends DescMessage, O extends DescMessage>(
 /**
  * Creates all options required to make a query. Useful in combination with `useQueries` from tanstack/react-query.
  */
-export function createUseQueryOptions<
+export function createQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
 >(
@@ -101,7 +101,10 @@ export function createUseQueryOptions<
 ): {
   queryKey: ConnectQueryKey<I>;
   queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<I>> | SkipToken;
-  structuralSharing: Exclude<UseQueryOptions["structuralSharing"], undefined>;
+  structuralSharing: Exclude<
+    TanStackUseQueryOptions["structuralSharing"],
+    undefined
+  >;
 } {
   const queryKey = createConnectQueryKey(schema, input);
   const structuralSharing = createStructuralSharing(schema.output);

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -53,9 +53,9 @@ export type UseQueryOptions<
 };
 
 /**
- * Options for useQuery
+ * Options for useSuspenseQuery
  */
-export type CreateSuspenseQueryOptions<
+export type UseSuspenseQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   SelectOutData = 0,

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -22,12 +22,12 @@ export {
 } from "./connect-query-key.js";
 export { createProtobufSafeUpdater } from "./utils.js";
 export { useTransport, TransportProvider } from "./use-transport.js";
-export type { CreateInfiniteQueryOptions as UseInfiniteQueryOptions } from "./create-use-infinite-query-options.js";
+export type { UseInfiniteQueryOptions } from "./create-infinite-query-options.js";
 export {
   useInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from "./use-infinite-query.js";
-export type { CreateQueryOptions as UseQueryOptions } from "./create-use-query-options.js";
+export type { UseQueryOptions } from "./create-query-options.js";
 export { useQuery, useSuspenseQuery } from "./use-query.js";
 export type { UseMutationOptions } from "./use-mutation.js";
 export { useMutation } from "./use-mutation.js";
@@ -35,5 +35,5 @@ export { defaultOptions } from "./default-options.js";
 export type { ConnectUpdater } from "./utils.js";
 export { callUnaryMethod } from "./call-unary-method.js";
 export type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
-export { createUseInfiniteQueryOptions as createInfiniteQueryOptions } from "./create-use-infinite-query-options.js";
-export { createUseQueryOptions as createQueryOptions } from "./create-use-query-options.js";
+export { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
+export { createQueryOptions } from "./create-query-options.js";

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -22,12 +22,10 @@ export {
 } from "./connect-query-key.js";
 export { createProtobufSafeUpdater } from "./utils.js";
 export { useTransport, TransportProvider } from "./use-transport.js";
-export type { UseInfiniteQueryOptions } from "./create-infinite-query-options.js";
 export {
   useInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from "./use-infinite-query.js";
-export type { UseQueryOptions } from "./create-query-options.js";
 export { useQuery, useSuspenseQuery } from "./use-query.js";
 export type { UseMutationOptions } from "./use-mutation.js";
 export { useMutation } from "./use-mutation.js";
@@ -37,3 +35,5 @@ export { callUnaryMethod } from "./call-unary-method.js";
 export type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 export { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
 export { createQueryOptions } from "./create-query-options.js";
+export type { UseInfiniteQueryOptions } from "./use-infinite-query.js";
+export type { UseQueryOptions } from "./use-query.js";

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -44,18 +44,21 @@ export type UseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends keyof MessageInitShape<I>,
-> = ConnectInfiniteQueryOptions<I, O, ParamKey> &
-  Omit<
-    TanStackUseInfiniteQueryOptions<
-      MessageShape<O>,
-      ConnectError,
-      InfiniteData<MessageShape<O>>,
-      MessageShape<O>,
-      ConnectInfiniteQueryKey<I>,
-      MessageInitShape<I>[ParamKey]
-    >,
-    "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
-  >;
+> = Omit<
+  TanStackUseInfiniteQueryOptions<
+    MessageShape<O>,
+    ConnectError,
+    InfiniteData<MessageShape<O>>,
+    MessageShape<O>,
+    ConnectInfiniteQueryKey<I>,
+    MessageInitShape<I>[ParamKey]
+  >,
+  "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
+> &
+  ConnectInfiniteQueryOptions<I, O, ParamKey> & {
+    /** The transport to be used for the fetching. */
+    transport?: Transport;
+  };
 
 /**
  * Query the method provided. Maps to useInfiniteQuery on tanstack/react-query
@@ -74,9 +77,7 @@ export function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: Omit<UseInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
-    transport?: Transport;
-  },
+  }: UseInfiniteQueryOptions<I, O, ParamKey>,
 ): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> {
   const transportFromCtx = useTransport();
   const baseOptions = createInfiniteQueryOptions(schema, input, {
@@ -97,18 +98,21 @@ export type UseSuspenseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends keyof MessageInitShape<I>,
-> = ConnectInfiniteQueryOptions<I, O, ParamKey> &
-  Omit<
-    TanStackUseSuspenseInfiniteQueryOptions<
-      MessageShape<O>,
-      ConnectError,
-      InfiniteData<MessageShape<O>>,
-      MessageShape<O>,
-      ConnectInfiniteQueryKey<I>,
-      MessageInitShape<I>[ParamKey]
-    >,
-    "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
-  >;
+> = Omit<
+  TanStackUseSuspenseInfiniteQueryOptions<
+    MessageShape<O>,
+    ConnectError,
+    InfiniteData<MessageShape<O>>,
+    MessageShape<O>,
+    ConnectInfiniteQueryKey<I>,
+    MessageInitShape<I>[ParamKey]
+  >,
+  "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
+> &
+  ConnectInfiniteQueryOptions<I, O, ParamKey> & {
+    /** The transport to be used for the fetching. */
+    transport?: Transport;
+  };
 
 /**
  * Query the method provided. Maps to useSuspenseInfiniteQuery on tanstack/react-query
@@ -125,9 +129,7 @@ export function useSuspenseInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: Omit<UseSuspenseInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
-    transport?: Transport;
-  },
+  }: UseSuspenseInfiniteQueryOptions<I, O, ParamKey>,
 ): UseSuspenseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> {
   const transportFromCtx = useTransport();
   const baseOptions = createInfiniteQueryOptions(schema, input, {

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -30,10 +30,10 @@ import {
 } from "@tanstack/react-query";
 
 import type {
-  CreateInfiniteQueryOptions,
-  CreateSuspenseInfiniteQueryOptions,
-} from "./create-use-infinite-query-options.js";
-import { createUseInfiniteQueryOptions } from "./create-use-infinite-query-options.js";
+  UseInfiniteQueryOptions,
+  UseSuspenseInfiniteQueryOptions,
+} from "./create-infinite-query-options.js";
+import { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { useTransport } from "./use-transport.js";
 
@@ -54,12 +54,12 @@ export function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: Omit<CreateInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
+  }: Omit<UseInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
     transport?: Transport;
   },
 ): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> {
   const transportFromCtx = useTransport();
-  const baseOptions = createUseInfiniteQueryOptions(schema, input, {
+  const baseOptions = createInfiniteQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
     getNextPageParam,
     pageParamKey,
@@ -85,12 +85,12 @@ export function useSuspenseInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: Omit<CreateSuspenseInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
+  }: Omit<UseSuspenseInfiniteQueryOptions<I, O, ParamKey>, "transport"> & {
     transport?: Transport;
   },
 ): UseSuspenseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> {
   const transportFromCtx = useTransport();
-  const baseOptions = createUseInfiniteQueryOptions(schema, input, {
+  const baseOptions = createInfiniteQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
     getNextPageParam,
     pageParamKey,

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -21,7 +21,9 @@ import type { ConnectError, Transport } from "@connectrpc/connect";
 import type {
   InfiniteData,
   SkipToken,
+  UseInfiniteQueryOptions as TanStackUseInfiniteQueryOptions,
   UseInfiniteQueryResult,
+  UseSuspenseInfiniteQueryOptions as TanStackUseSuspenseInfiniteQueryOptions,
   UseSuspenseInfiniteQueryResult,
 } from "@tanstack/react-query";
 import {
@@ -29,13 +31,31 @@ import {
   useSuspenseInfiniteQuery as tsUseSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
 
-import type {
-  UseInfiniteQueryOptions,
-  UseSuspenseInfiniteQueryOptions,
-} from "./create-infinite-query-options.js";
+import type { ConnectInfiniteQueryKey } from "./connect-query-key.js";
+import type { ConnectInfiniteQueryOptions } from "./create-infinite-query-options.js";
 import { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { useTransport } from "./use-transport.js";
+
+/**
+ * Options for useInfiniteQuery
+ */
+export type UseInfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+> = ConnectInfiniteQueryOptions<I, O, ParamKey> &
+  Omit<
+    TanStackUseInfiniteQueryOptions<
+      MessageShape<O>,
+      ConnectError,
+      InfiniteData<MessageShape<O>>,
+      MessageShape<O>,
+      ConnectInfiniteQueryKey<I>,
+      MessageInitShape<I>[ParamKey]
+    >,
+    "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
+  >;
 
 /**
  * Query the method provided. Maps to useInfiniteQuery on tanstack/react-query
@@ -69,6 +89,26 @@ export function useInfiniteQuery<
     ...queryOptions,
   });
 }
+
+/**
+ * Options for useSuspenseInfiniteQuery
+ */
+export type UseSuspenseInfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+> = ConnectInfiniteQueryOptions<I, O, ParamKey> &
+  Omit<
+    TanStackUseSuspenseInfiniteQueryOptions<
+      MessageShape<O>,
+      ConnectError,
+      InfiniteData<MessageShape<O>>,
+      MessageShape<O>,
+      ConnectInfiniteQueryKey<I>,
+      MessageInitShape<I>[ParamKey]
+    >,
+    "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
+  >;
 
 /**
  * Query the method provided. Maps to useSuspenseInfiniteQuery on tanstack/react-query

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -29,7 +29,7 @@ import {
 } from "@tanstack/react-query";
 
 import type {
-  CreateSuspenseQueryOptions,
+  UseSuspenseQueryOptions,
   UseQueryOptions,
 } from "./create-query-options.js";
 import { createQueryOptions } from "./create-query-options.js";
@@ -76,7 +76,7 @@ export function useSuspenseQuery<
   {
     transport,
     ...queryOptions
-  }: Omit<CreateSuspenseQueryOptions<I, O, SelectOutData>, "transport"> & {
+  }: Omit<UseSuspenseQueryOptions<I, O, SelectOutData>, "transport"> & {
     transport?: Transport;
   } = {},
 ): UseSuspenseQueryResult<SelectOutData, ConnectError> {

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -29,10 +29,10 @@ import {
 } from "@tanstack/react-query";
 
 import type {
-  CreateQueryOptions,
   CreateSuspenseQueryOptions,
-} from "./create-use-query-options.js";
-import { createUseQueryOptions } from "./create-use-query-options.js";
+  UseQueryOptions,
+} from "./create-query-options.js";
+import { createQueryOptions } from "./create-query-options.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { useTransport } from "./use-transport.js";
 
@@ -49,12 +49,12 @@ export function useQuery<
   {
     transport,
     ...queryOptions
-  }: Omit<CreateQueryOptions<I, O, SelectOutData>, "transport"> & {
+  }: Omit<UseQueryOptions<I, O, SelectOutData>, "transport"> & {
     transport?: Transport;
   } = {},
 ): UseQueryResult<SelectOutData, ConnectError> {
   const transportFromCtx = useTransport();
-  const baseOptions = createUseQueryOptions(schema, input, {
+  const baseOptions = createQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
   });
   return tsUseQuery({
@@ -81,7 +81,7 @@ export function useSuspenseQuery<
   } = {},
 ): UseSuspenseQueryResult<SelectOutData, ConnectError> {
   const transportFromCtx = useTransport();
-  const baseOptions = createUseQueryOptions(schema, input, {
+  const baseOptions = createQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
   });
   return tsUseSuspenseQuery({

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -20,7 +20,9 @@ import type {
 import type { ConnectError, Transport } from "@connectrpc/connect";
 import type {
   SkipToken,
+  UseQueryOptions as TanStackUseQueryOptions,
   UseQueryResult,
+  UseSuspenseQueryOptions as TanStackUseSuspenseQueryOptions,
   UseSuspenseQueryResult,
 } from "@tanstack/react-query";
 import {
@@ -28,13 +30,30 @@ import {
   useSuspenseQuery as tsUseSuspenseQuery,
 } from "@tanstack/react-query";
 
-import type {
-  UseSuspenseQueryOptions,
-  UseQueryOptions,
-} from "./create-query-options.js";
+import type { ConnectQueryKey } from "./connect-query-key.js";
 import { createQueryOptions } from "./create-query-options.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { useTransport } from "./use-transport.js";
+
+/**
+ * Options for useQuery
+ */
+export type UseQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  SelectOutData = MessageShape<O>,
+> = Omit<
+  TanStackUseQueryOptions<
+    MessageShape<O>,
+    ConnectError,
+    SelectOutData,
+    ConnectQueryKey<I>
+  >,
+  "queryFn" | "queryKey"
+> & {
+  /** The transport to be used for the fetching. */
+  transport?: Transport;
+};
 
 /**
  * Query the method provided. Maps to useQuery on tanstack/react-query
@@ -46,12 +65,7 @@ export function useQuery<
 >(
   schema: MethodUnaryDescriptor<I, O>,
   input?: SkipToken | MessageInitShape<I>,
-  {
-    transport,
-    ...queryOptions
-  }: Omit<UseQueryOptions<I, O, SelectOutData>, "transport"> & {
-    transport?: Transport;
-  } = {},
+  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {},
 ): UseQueryResult<SelectOutData, ConnectError> {
   const transportFromCtx = useTransport();
   const baseOptions = createQueryOptions(schema, input, {
@@ -62,6 +76,26 @@ export function useQuery<
     ...queryOptions,
   });
 }
+
+/**
+ * Options for useSuspenseQuery
+ */
+export type UseSuspenseQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  SelectOutData = 0,
+> = Omit<
+  TanStackUseSuspenseQueryOptions<
+    MessageShape<O>,
+    ConnectError,
+    SelectOutData,
+    ConnectQueryKey<I>
+  >,
+  "queryFn" | "queryKey"
+> & {
+  /** The transport to be used for the fetching. */
+  transport?: Transport;
+};
 
 /**
  * Query the method provided. Maps to useSuspenseQuery on tanstack/react-query
@@ -76,9 +110,7 @@ export function useSuspenseQuery<
   {
     transport,
     ...queryOptions
-  }: Omit<UseSuspenseQueryOptions<I, O, SelectOutData>, "transport"> & {
-    transport?: Transport;
-  } = {},
+  }: UseSuspenseQueryOptions<I, O, SelectOutData> = {},
 ): UseSuspenseQueryResult<SelectOutData, ConnectError> {
   const transportFromCtx = useTransport();
   const baseOptions = createQueryOptions(schema, input, {


### PR DESCRIPTION
This renames functions and types to match their export names. For context, see https://github.com/connectrpc/connect-query-es/pull/436#discussion_r1786200957.

The first two commits rename symbols. The other commits co-locate the option types with their hooks and simplify them.