### PR TITLE
Remove preview script

### DIFF
--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -7,7 +7,6 @@
     "dev": "vite",
     "generate": "rm -rf src/gen && buf generate --path eliza.proto",
     "license-header": "license-header",
-    "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest --watch --ui",
     "format": "prettier . --write && eslint . --fix && license-header"


### PR DESCRIPTION
Fixes #442 

The preview script doesn't make sense without a build step and `npm run dev` works fine enough to demo the functionality.