### PR TITLE
V2: Add utility to support explicit key on transport

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,12 +26,7 @@ const config = {
   parserOptions: {
     project: true,
   },
-  plugins: [
-    "@typescript-eslint",
-    "import",
-    "simple-import-sort",
-    "vitest",
-  ],
+  plugins: ["@typescript-eslint", "import", "simple-import-sort", "vitest"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/all",

--- a/README.md
+++ b/README.md
@@ -249,13 +249,12 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 ### `createConnectQueryKey`
 
 ```ts
-function createConnectQueryKey<I extends Message<I>, O extends Message<O>>(
-  methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
-  input?: SkipToken | PartialMessage<I> | undefined,
-): ConnectQueryKey<I>;
+function createConnectQueryKey<Desc extends DescMethod | DescService>(
+  params: KeyParams<Desc>,
+): ConnectQueryKey;
 ```
 
-This helper is useful to manually compute the [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) sent to TanStack Query. This function has no side effects.
+This function is used under the hood of `useQuery` and other hooks to compute a [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) for TanStack Query. You can use it to create (partial) keys yourself to filter queries.
 
 ### `createConnectInfiniteQueryKey`
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ function useQuery<
 >(
   schema: MethodUnaryDescriptor<I, O>,
   input?: SkipToken | MessageInitShape<I>,
-  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {}
+  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {},
 ): UseQueryResult<SelectOutData, ConnectError>;
 ```
 
@@ -226,7 +226,7 @@ function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: UseInfiniteQueryOptions<I, O, ParamKey>
+  }: UseInfiniteQueryOptions<I, O, ParamKey>,
 ): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError>;
 ```
 
@@ -243,7 +243,7 @@ Identical to useInfiniteQuery but mapping to the `useSuspenseInfiniteQuery` hook
 ```ts
 function useMutation<I extends DescMessage, O extends DescMessage>(
   schema: MethodUnaryDescriptor<I, O>,
-  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {}
+  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {},
 ): UseMutationResult<MessageShape<O>, ConnectError, PartialMessage<I>>;
 ```
 
@@ -255,7 +255,7 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 
 ```ts
 function createConnectQueryKey<Desc extends DescMethod | DescService>(
-  params: KeyParams<Desc>
+  params: KeyParams<Desc>,
 ): ConnectQueryKey;
 ```
 
@@ -270,7 +270,7 @@ function createConnectInfiniteQueryKey<
 >(
   methodDescriptor: Pick<MethodUnaryDescriptor<I, O>, "I" | "name" | "service">,
   input: SkipToken | PartialMessage<I>,
-  pageParamKey: keyof PartialMessage<I>
+  pageParamKey: keyof PartialMessage<I>,
 ): ConnectInfiniteQueryKey<I>;
 ```
 
@@ -285,7 +285,7 @@ function callUnaryMethod<I extends DescMessage, O extends DescMessage>(
   input: MessageInitShape<I> | undefined,
   options?: {
     signal?: AbortSignal;
-  }
+  },
 ): Promise<O>;
 ```
 
@@ -323,7 +323,7 @@ function createQueryOptions<I extends DescMessage, O extends DescMessage>(
     transport,
   }: {
     transport: Transport;
-  }
+  },
 ): {
   queryKey: ConnectQueryKey<I>;
   queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<I>> | SkipToken;
@@ -366,7 +366,7 @@ function createInfiniteQueryOptions<
     transport,
     getNextPageParam,
     pageParamKey,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey>
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,

--- a/examples/react/basic/vite.config.ts
+++ b/examples/react/basic/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     environment: "jsdom",
     typecheck: {
       enabled: true,
-      // Mofidied to typecheck definition files as well as source files
+      // Modified to typecheck definition files as well as source files
       include: ["**/*.{test,spec}?(-d).?(c|m)[jt]s?(x)"],
     },
   },

--- a/packages/connect-query/src/call-unary-method.test.ts
+++ b/packages/connect-query/src/call-unary-method.test.ts
@@ -40,7 +40,7 @@ describe("callUnaryMethod", () => {
           queries: [
             {
               queryKey: createConnectQueryKey({
-                method: ElizaService.method.say,
+                schema: ElizaService.method.say,
                 input,
                 transport,
               }),

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -23,7 +23,7 @@ import { createMessageKey } from "./message-key.js";
 describe("createConnectQueryKey", () => {
   it("makes a query key with input", () => {
     const key = createConnectQueryKey({
-      method: ElizaService.method.say,
+      schema: ElizaService.method.say,
       input: create(SayRequestSchema, { sentence: "hi" }),
     });
     expect(key).toStrictEqual([
@@ -39,7 +39,7 @@ describe("createConnectQueryKey", () => {
 
   it("allows input: undefined", () => {
     const key = createConnectQueryKey({
-      method: ElizaService.method.say,
+      schema: ElizaService.method.say,
       input: undefined,
     });
     expect(key).toStrictEqual([
@@ -54,7 +54,7 @@ describe("createConnectQueryKey", () => {
 
   it("allows to omit input", () => {
     const key = createConnectQueryKey({
-      method: ElizaService.method.say,
+      schema: ElizaService.method.say,
     });
     expect(key).toStrictEqual([
       "connect-query",
@@ -68,7 +68,7 @@ describe("createConnectQueryKey", () => {
 
   it("skipToken sets input: 'skipped'", () => {
     const key = createConnectQueryKey({
-      method: ElizaService.method.say,
+      schema: ElizaService.method.say,
       input: skipToken,
     });
     expect(key[1].input).toBe("skipped");
@@ -76,7 +76,7 @@ describe("createConnectQueryKey", () => {
 
   it("creates an example key", () => {
     const key = createConnectQueryKey({
-      method: ElizaService.method.say,
+      schema: ElizaService.method.say,
       input: { sentence: "hello there" },
     });
     expect(key).toStrictEqual([

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -73,4 +73,22 @@ describe("createConnectQueryKey", () => {
     });
     expect(key[1].input).toBe("skipped");
   });
+
+  it("creates an example key", () => {
+    const key = createConnectQueryKey({
+      method: ElizaService.method.say,
+      input: { sentence: "hello there" },
+    });
+    expect(key).toStrictEqual([
+      "connect-query",
+      {
+        serviceName: "connectrpc.eliza.v1.ElizaService",
+        methodName: "Say",
+        input: {
+          sentence: "hello there",
+        },
+        cardinality: "finite",
+      },
+    ]);
+  });
 });

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -146,21 +146,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
  * });
  * ```
  *
- * Note that the factory allows to create partial keys that can be used to filter queries. For example:
- *
- * ```ts
- * createConnectQueryKey({
- *   schema: ElizaService,
- * });
- *
- * // creates the key:
- * [
- *   "connect-query",
- *   {
- *     serviceName: "connectrpc.eliza.v1.ElizaService",
- *   }
- * ]
- * ```
+ * Note that the factory allows to create partial keys that can be used to filter queries. For example, you can create a key without a transport, any cardinality, any input message, or with a partial input message.
  *
  * @see ConnectQueryKey for information on the components of Connect-Query's keys.
  */

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DescMessage, MessageInitShape } from "@bufbuild/protobuf";
+import type {
+  DescMethod,
+  DescService,
+  MessageInitShape,
+} from "@bufbuild/protobuf";
+import type { Transport } from "@connectrpc/connect";
 import type { SkipToken } from "@tanstack/react-query";
-import { skipToken } from "@tanstack/react-query";
 
 import { createMessageKey } from "./message-key.js";
-import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
+import { createTransportKey } from "./transport-key.js";
 
 /**
  * TanStack Query requires query keys in order to decide when the query should automatically update.
+ *
+ *
+ * TODO
  *
  * `QueryKey`s in TanStack Query are usually arbitrary, but Connect-Query uses the approach of creating a query key that begins with the least specific information: the service's `typeName`, followed by the method name, and ending with the most specific information to identify a particular request: the input message itself.
  *
@@ -34,10 +41,72 @@ import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
  * ]
  */
 export type ConnectQueryKey = [
-  serviceTypeName: string,
-  methodName: string,
-  input: Record<string, unknown>,
+  "connect-query",
+  {
+    /**
+     * A key for a Transport reference, created with createTransportKey().
+     */
+    transport?: string;
+    /**
+     * The name of the service, e.g. connectrpc.eliza.v1.ElizaService
+     */
+    serviceName: string;
+    /**
+     * The name of the method, e.g. Say.
+     */
+    methodName?: string;
+    /**
+     * Whether this is an infinite query, or a regular one.
+     */
+    cardinality?: "infinite" | "finite";
+    /**
+     * A key for the request message, created with createMessageKey(),
+     * or "skipped".
+     */
+    input?: Record<string, unknown> | "skipped";
+  },
 ];
+
+type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
+  ? {
+      /**
+       * Set `serviceName` and `methodName` in the key.
+       */
+      method: Desc;
+      /**
+       * Set `input` in the key:
+       * - If a SkipToken is provided, `input` is "skipped".
+       * - If an init shape is provided, `input` is set to a message key.
+       * - If omitted or undefined, `input` is not set in the key.
+       */
+      input?: MessageInitShape<Desc["input"]> | SkipToken | undefined;
+      /**
+       * Set `transport` in the key.
+       */
+      transport?: Transport;
+      /**
+       * Set `cardinality` in the key - "finite" by default.
+       */
+      cardinality?: "finite" | "infinite" | "any";
+      /**
+       * If omit the field with this name from the key for infinite queries.
+       */
+      pageParamKey?: keyof MessageInitShape<Desc["input"]>;
+    }
+  : {
+      /**
+       * Set `serviceName` in the key, and omit `methodName`.
+       */
+      service: Desc;
+      /**
+       * Set `transport` in the key.
+       */
+      transport?: Transport;
+      /**
+       * Set `cardinality` in the key - "finite" by default.
+       */
+      cardinality?: "finite" | "infinite" | "any";
+    };
 
 /**
  * TanStack Query requires query keys in order to decide when the query should automatically update.
@@ -46,39 +115,46 @@ export type ConnectQueryKey = [
  *
  * @see ConnectQueryKey for information on the components of Connect-Query's keys.
  */
-export function createConnectQueryKey<
-  I extends DescMessage,
-  O extends DescMessage,
->(
-  schema: Pick<MethodUnaryDescriptor<I, O>, "input" | "parent" | "name">,
-  input?: SkipToken | MessageInitShape<I> | undefined,
+export function createConnectQueryKey<Desc extends DescMethod | DescService>(
+  params: KeyParams<Desc>,
 ): ConnectQueryKey {
-  const key =
-    input === skipToken || input === undefined
-      ? createMessageKey(schema.input, {} as MessageInitShape<DescMessage & I>)
-      : createMessageKey(schema.input, input);
-  return [schema.parent.typeName, schema.name, key];
-}
-
-/**
- * Similar to @see ConnectQueryKey, but for infinite queries.
- */
-export type ConnectInfiniteQueryKey = [
-  serviceTypeName: string,
-  methodName: string,
-  input: Record<string, unknown>,
-  "infinite",
-];
-
-/**
- * Similar to @see createConnectQueryKey, but for infinite queries.
- */
-export function createConnectInfiniteQueryKey<
-  I extends DescMessage,
-  O extends DescMessage,
->(
-  schema: Pick<MethodUnaryDescriptor<I, O>, "input" | "parent" | "name">,
-  input?: SkipToken | MessageInitShape<I> | undefined,
-): ConnectInfiniteQueryKey {
-  return [...createConnectQueryKey(schema, input), "infinite"];
+  const props: ConnectQueryKey[1] =
+    "method" in params
+      ? {
+          serviceName: params.method.parent.typeName,
+          methodName: params.method.name,
+        }
+      : {
+          serviceName: params.service.typeName,
+        };
+  if (params.transport !== undefined) {
+    props.transport = createTransportKey(params.transport);
+  }
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- "Cases not matched: undefined" 🤷
+  switch (params.cardinality) {
+    case undefined:
+    case "finite":
+      props.cardinality = "finite";
+      break;
+    case "infinite":
+      props.cardinality = "infinite";
+      break;
+    case "any":
+      break;
+  }
+  if ("method" in params && typeof params.input == "symbol") {
+    props.input = "skipped";
+  }
+  if ("method" in params) {
+    if (typeof params.input == "symbol") {
+      props.input = "skipped";
+    } else if (params.input !== undefined) {
+      props.input = createMessageKey(
+        params.method.input,
+        params.input,
+        params.pageParamKey,
+      );
+    }
+  }
+  return ["connect-query", props];
 }

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -77,7 +77,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
       /**
        * Set `serviceName` and `methodName` in the key.
        */
-      method: Desc;
+      schema: Desc;
       /**
        * Set `input` in the key:
        * - If a SkipToken is provided, `input` is "skipped".
@@ -102,7 +102,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
       /**
        * Set `serviceName` in the key, and omit `methodName`.
        */
-      service: Desc;
+      schema: Desc;
       /**
        * Set `transport` in the key.
        */
@@ -141,7 +141,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
  * ```ts
  * createConnectQueryKey({
  *   transport: myTransportReference,
- *   method: ElizaService.method.say,
+ *   schema: ElizaService.method.say,
  *   input: { sentence: "hello" }
  * });
  * ```
@@ -150,7 +150,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
  *
  * ```ts
  * createConnectQueryKey({
- *   service: ElizaService,
+ *   schema: ElizaService,
  * });
  *
  * // creates the key:
@@ -168,13 +168,13 @@ export function createConnectQueryKey<Desc extends DescMethod | DescService>(
   params: KeyParams<Desc>,
 ): ConnectQueryKey {
   const props: ConnectQueryKey[1] =
-    "method" in params
+    params.schema.kind == "rpc"
       ? {
-          serviceName: params.method.parent.typeName,
-          methodName: params.method.name,
+          serviceName: params.schema.parent.typeName,
+          methodName: params.schema.name,
         }
       : {
-          serviceName: params.service.typeName,
+          serviceName: params.schema.typeName,
         };
   if (params.transport !== undefined) {
     props.transport = createTransportKey(params.transport);
@@ -191,15 +191,12 @@ export function createConnectQueryKey<Desc extends DescMethod | DescService>(
     case "any":
       break;
   }
-  if ("method" in params && typeof params.input == "symbol") {
-    props.input = "skipped";
-  }
-  if ("method" in params) {
+  if (params.schema.kind == "rpc" && "input" in params) {
     if (typeof params.input == "symbol") {
       props.input = "skipped";
     } else if (params.input !== undefined) {
       props.input = createMessageKey(
-        params.method.input,
+        params.schema.input,
         params.input,
         params.pageParamKey,
       );

--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -29,8 +29,8 @@ import { skipToken } from "@tanstack/react-query";
 
 import { callUnaryMethod } from "./call-unary-method.js";
 import {
-  type ConnectInfiniteQueryKey,
-  createConnectInfiniteQueryKey,
+  type ConnectQueryKey,
+  createConnectQueryKey,
 } from "./connect-query-key.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 import { createStructuralSharing } from "./structural-sharing.js";
@@ -69,7 +69,7 @@ function createUnaryInfiniteQueryFn<
   },
 ): QueryFunction<
   MessageShape<O>,
-  ConnectInfiniteQueryKey,
+  ConnectQueryKey,
   MessageInitShape<I>[ParamKey]
 > {
   return async (context) => {
@@ -108,11 +108,11 @@ export function createInfiniteQueryOptions<
     O,
     ParamKey
   >["getNextPageParam"];
-  queryKey: ConnectInfiniteQueryKey;
+  queryKey: ConnectQueryKey;
   queryFn:
     | QueryFunction<
         MessageShape<O>,
-        ConnectInfiniteQueryKey,
+        ConnectQueryKey,
         MessageInitShape<I>[ParamKey]
       >
     | SkipToken;
@@ -120,15 +120,12 @@ export function createInfiniteQueryOptions<
   initialPageParam: MessageInitShape<I>[ParamKey];
   queryKeyHashFn: (queryKey: QueryKey) => string;
 } {
-  const queryKey = createConnectInfiniteQueryKey(
-    schema,
-    input === skipToken
-      ? undefined
-      : {
-          ...input,
-          [pageParamKey]: undefined,
-        },
-  );
+  const queryKey = createConnectQueryKey({
+    cardinality: "infinite",
+    method: schema,
+    transport,
+    input,
+  });
   const structuralSharing = createStructuralSharing(schema.output);
   const queryFn =
     input === skipToken

--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -122,7 +122,7 @@ export function createInfiniteQueryOptions<
 } {
   const queryKey = createConnectQueryKey({
     cardinality: "infinite",
-    method: schema,
+    schema,
     transport,
     input,
   });

--- a/packages/connect-query/src/create-query-options.test.ts
+++ b/packages/connect-query/src/create-query-options.test.ts
@@ -34,7 +34,7 @@ describe("createQueryOptions", () => {
   });
   it("sets queryKey", () => {
     const want = createConnectQueryKey({
-      method: sayMethodDescriptor,
+      schema: sayMethodDescriptor,
       input: { sentence: "hi" },
       transport: mockedElizaTransport,
     });

--- a/packages/connect-query/src/create-query-options.test.ts
+++ b/packages/connect-query/src/create-query-options.test.ts
@@ -25,7 +25,7 @@ const sayMethodDescriptor = ElizaService.method.say;
 
 const mockedElizaTransport = mockEliza();
 
-describe("createUseQueryOptions", () => {
+describe("createQueryOptions", () => {
   it("honors skipToken", () => {
     const opt = createQueryOptions(sayMethodDescriptor, skipToken, {
       transport: mockedElizaTransport,
@@ -33,7 +33,11 @@ describe("createUseQueryOptions", () => {
     expect(opt.queryFn).toBe(skipToken);
   });
   it("sets queryKey", () => {
-    const want = createConnectQueryKey(sayMethodDescriptor, { sentence: "hi" });
+    const want = createConnectQueryKey({
+      method: sayMethodDescriptor,
+      input: { sentence: "hi" },
+      transport: mockedElizaTransport,
+    });
     const opt = createQueryOptions(
       sayMethodDescriptor,
       { sentence: "hi" },

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -17,6 +17,7 @@ import type {
   MessageInitShape,
   MessageShape,
 } from "@bufbuild/protobuf";
+import { create } from "@bufbuild/protobuf";
 import type { Transport } from "@connectrpc/connect";
 import type {
   QueryFunction,
@@ -67,7 +68,11 @@ export function createQueryOptions<
   >;
   queryKeyHashFn: (queryKey: QueryKey) => string;
 } {
-  const queryKey = createConnectQueryKey(schema, input);
+  const queryKey = createConnectQueryKey({
+    method: schema,
+    input: input ?? create(schema.input),
+    transport,
+  });
   const structuralSharing = createStructuralSharing(schema.output);
   const queryFn =
     input === skipToken

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -69,7 +69,7 @@ export function createQueryOptions<
   queryKeyHashFn: (queryKey: QueryKey) => string;
 } {
   const queryKey = createConnectQueryKey({
-    method: schema,
+    schema,
     input: input ?? create(schema.input),
     transport,
   });

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export type {
-  ConnectQueryKey,
-  ConnectInfiniteQueryKey,
-} from "./connect-query-key.js";
-export {
-  createConnectQueryKey,
-  createConnectInfiniteQueryKey,
-} from "./connect-query-key.js";
+export type { ConnectQueryKey } from "./connect-query-key.js";
+export { createConnectQueryKey } from "./connect-query-key.js";
 export { createProtobufSafeUpdater } from "./utils.js";
 export { useTransport, TransportProvider } from "./use-transport.js";
 export {

--- a/packages/connect-query/src/index.ts
+++ b/packages/connect-query/src/index.ts
@@ -31,3 +31,4 @@ export { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
 export { createQueryOptions } from "./create-query-options.js";
 export type { UseInfiniteQueryOptions } from "./use-infinite-query.js";
 export type { UseQueryOptions } from "./use-query.js";
+export { addStaticKeyToTransport } from "./transport-key.js";

--- a/packages/connect-query/src/message-key.test.ts
+++ b/packages/connect-query/src/message-key.test.ts
@@ -32,6 +32,17 @@ describe("message key", () => {
     const key = createMessageKey(schema, message);
     expect(key).toStrictEqual({});
   });
+  it("omits the pageParamKey", () => {
+    const schema = Proto3MessageSchema;
+    const message = create(schema, {
+      int32Field: 123,
+      stringField: "abc",
+    });
+    const key = createMessageKey(schema, message, "int32Field");
+    expect(key).toStrictEqual({
+      stringField: "abc",
+    });
+  });
   it("converts as expected", () => {
     const key = createMessageKey(Proto3MessageSchema, {
       int64Field: 123n,

--- a/packages/connect-query/src/transport-key.test.ts
+++ b/packages/connect-query/src/transport-key.test.ts
@@ -45,7 +45,7 @@ describe("transport key", () => {
       createConnectTransport({
         baseUrl: "https://example.com",
       }),
-      "static-key"
+      "static-key",
     );
     const key1 = createTransportKey(transport1);
     expect(key1).toBe("static-key");

--- a/packages/connect-query/src/transport-key.test.ts
+++ b/packages/connect-query/src/transport-key.test.ts
@@ -15,7 +15,10 @@
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { describe, expect, it } from "vitest";
 
-import { createTransportKey } from "./transport-key.js";
+import {
+  addStaticKeyToTransport,
+  createTransportKey,
+} from "./transport-key.js";
 
 describe("transport key", () => {
   it("returns the same key for the same reference", () => {
@@ -36,5 +39,15 @@ describe("transport key", () => {
     const key1 = createTransportKey(transport1);
     const key2 = createTransportKey(transport2);
     expect(key1).not.toBe(key2);
+  });
+  it("allows override of key transport property", () => {
+    const transport1 = addStaticKeyToTransport(
+      createConnectTransport({
+        baseUrl: "https://example.com",
+      }),
+      "static-key"
+    );
+    const key1 = createTransportKey(transport1);
+    expect(key1).toBe("static-key");
   });
 });

--- a/packages/connect-query/src/transport-key.ts
+++ b/packages/connect-query/src/transport-key.ts
@@ -48,7 +48,7 @@ export function createTransportKey(transport: TransportWithStaticKey): string {
  */
 export function addStaticKeyToTransport(
   transport: Transport,
-  key: string
+  key: string,
 ): TransportWithStaticKey {
   return { ...transport, [staticKeySymbol]: key };
 }

--- a/packages/connect-query/src/transport-key.ts
+++ b/packages/connect-query/src/transport-key.ts
@@ -14,8 +14,14 @@
 
 import type { Transport } from "@connectrpc/connect";
 
+const staticKeySymbol = Symbol("static-key");
+
 const transportKeys = new WeakMap<Transport, string>();
 let counter = 0;
+
+interface TransportWithStaticKey extends Transport {
+  [staticKeySymbol]?: string;
+}
 
 /**
  * For a given Transport, create a string key that is suitable for a Query Key
@@ -23,11 +29,26 @@ let counter = 0;
  *
  * This function will return a unique string for every reference.
  */
-export function createTransportKey(transport: Transport): string {
+export function createTransportKey(transport: TransportWithStaticKey): string {
+  if (transport[staticKeySymbol] !== undefined) {
+    return transport[staticKeySymbol];
+  }
   let key = transportKeys.get(transport);
   if (key === undefined) {
     key = `t${++counter}`;
     transportKeys.set(transport, key);
   }
   return key;
+}
+
+/**
+ * Enhances a given transport with a static query key that is used in any associated queries. This may be necessary
+ * in SSR contexts where transports are used on both client and server but they need to be considered
+ * the same when it comes to the query cache.
+ */
+export function addStaticKeyToTransport(
+  transport: Transport,
+  key: string
+): TransportWithStaticKey {
+  return { ...transport, [staticKeySymbol]: key };
 }

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -195,7 +195,7 @@ describe("useInfiniteQuery", () => {
     expect(cache).toHaveLength(1);
     expect(cache[0].queryKey).toEqual(
       createConnectQueryKey({
-        method: methodDescriptor,
+        schema: methodDescriptor,
         transport: mockedPaginatedTransport,
         cardinality: "infinite",
         pageParamKey: "page",
@@ -282,7 +282,7 @@ describe("useInfiniteQuery", () => {
 
     await queryClient.invalidateQueries({
       queryKey: createConnectQueryKey({
-        method: methodDescriptor,
+        schema: methodDescriptor,
         transport: mockedPaginatedTransport,
         cardinality: "any",
         pageParamKey: "page",
@@ -329,7 +329,7 @@ describe("useInfiniteQuery", () => {
     await queryClient.invalidateQueries({
       exact: false,
       queryKey: createConnectQueryKey({
-        method: methodDescriptor,
+        schema: methodDescriptor,
         cardinality: "infinite",
       }),
     });

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -31,7 +31,7 @@ import {
   useSuspenseInfiniteQuery as tsUseSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
 
-import type { ConnectInfiniteQueryKey } from "./connect-query-key.js";
+import type { ConnectQueryKey } from "./connect-query-key.js";
 import type { ConnectInfiniteQueryOptions } from "./create-infinite-query-options.js";
 import { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
@@ -50,7 +50,7 @@ export type UseInfiniteQueryOptions<
     ConnectError,
     InfiniteData<MessageShape<O>>,
     MessageShape<O>,
-    ConnectInfiniteQueryKey,
+    ConnectQueryKey,
     MessageInitShape<I>[ParamKey]
   >,
   "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
@@ -104,7 +104,7 @@ export type UseSuspenseInfiniteQueryOptions<
     ConnectError,
     InfiniteData<MessageShape<O>>,
     MessageShape<O>,
-    ConnectInfiniteQueryKey,
+    ConnectQueryKey,
     MessageInitShape<I>[ParamKey]
   >,
   "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"

--- a/packages/connect-query/src/use-query.test.ts
+++ b/packages/connect-query/src/use-query.test.ts
@@ -58,15 +58,16 @@ describe("useQuery", () => {
   });
 
   it("can be provided a custom transport", async () => {
+    const transport = mockEliza({
+      sentence: "Intercepted!",
+    });
     const { result } = renderHook(
       () => {
         return useQuery(
           sayMethodDescriptor,
           {},
           {
-            transport: mockEliza({
-              sentence: "Intercepted!",
-            }),
+            transport,
           },
         );
       },

--- a/packages/connect-query/src/use-transport.tsx
+++ b/packages/connect-query/src/use-transport.tsx
@@ -18,7 +18,7 @@ import type { FC, PropsWithChildren } from "react";
 import { createContext, useContext } from "react";
 
 const fallbackTransportError = new ConnectError(
-  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info.",
+  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info."
 );
 
 // istanbul ignore next

--- a/packages/connect-query/src/use-transport.tsx
+++ b/packages/connect-query/src/use-transport.tsx
@@ -18,7 +18,7 @@ import type { FC, PropsWithChildren } from "react";
 import { createContext, useContext } from "react";
 
 const fallbackTransportError = new ConnectError(
-  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info."
+  "To use Connect, you must provide a `Transport`: a simple object that handles `unary` and `stream` requests. `Transport` objects can easily be created by using `@connectrpc/connect-web`'s exports `createConnectTransport` and `createGrpcWebTransport`. see: https://connectrpc.com/docs/web/getting-started for more info.",
 );
 
 // istanbul ignore next

--- a/packages/connect-query/vite.config.ts
+++ b/packages/connect-query/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     environment: "jsdom",
     typecheck: {
       enabled: true,
-      // Mofidied to typecheck definition files as well as source files
+      // Modified to typecheck definition files as well as source files
       include: ["**/*.{test,spec}?(-d).?(c|m)[jt]s?(x)"],
     },
     coverage: {


### PR DESCRIPTION
This adds a function that can apply a static key to a transport, useful when considering SSR contexts where the transport on the client is not the same transport as on the server.