### PR TITLE
V2: Update createProtobufSafeUpdater

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ const queryClient = useQueryClient();
 queryClient.setQueryData(
   createConnectQueryKey(example),
   createProtobufSafeUpdater(example, (prev) => {
+    if (prev === undefined) {
+      return undefined;
+    }
     return {
       ...prev,
       completed: true,

--- a/packages/connect-query/src/utils.test.ts
+++ b/packages/connect-query/src/utils.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { create, isMessage } from "@bufbuild/protobuf";
+import { create, isFieldSet, isMessage } from "@bufbuild/protobuf";
 import { describe, expect, it } from "vitest";
 
 import { Proto2MessageSchema } from "./gen/proto2_pb.js";
@@ -137,10 +137,14 @@ describe("createProtobufSafeUpdater", () => {
       const next = safeUpdater(prev);
       expect(next).toBeDefined();
     });
-    it("updates message", () => {
+    it("returns message", () => {
       const prev = create(Proto2MessageSchema);
       const next = safeUpdater(prev);
       expect(isMessage(next, Proto2MessageSchema)).toBe(true);
+    });
+    it("updates field", () => {
+      const prev = create(Proto2MessageSchema);
+      const next = safeUpdater(prev);
       expect(next?.int32Field).toBe(999);
     });
     it("keeps existing fields", () => {
@@ -149,6 +153,34 @@ describe("createProtobufSafeUpdater", () => {
       });
       const next = safeUpdater(prev);
       expect(next?.stringField).toBe("abc");
+    });
+    describe("keeps field presence", () => {
+      it("for unset field", () => {
+        const prev = create(Proto2MessageSchema);
+        expect(isFieldSet(prev, Proto2MessageSchema.field.stringField)).toBe(
+          false,
+        );
+        const next = safeUpdater(prev);
+        const hasStringField =
+          next === undefined
+            ? undefined
+            : isFieldSet(next, Proto2MessageSchema.field.stringField);
+        expect(hasStringField).toBe(false);
+      });
+      it("for set field", () => {
+        const prev = create(Proto2MessageSchema, {
+          stringField: "abc",
+        });
+        expect(isFieldSet(prev, Proto2MessageSchema.field.stringField)).toBe(
+          true,
+        );
+        const next = safeUpdater(prev);
+        const hasStringField =
+          next === undefined
+            ? undefined
+            : isFieldSet(next, Proto2MessageSchema.field.stringField);
+        expect(hasStringField).toBe(true);
+      });
     });
   });
 });

--- a/packages/connect-query/src/utils.ts
+++ b/packages/connect-query/src/utils.ts
@@ -56,7 +56,6 @@ export const isAbortController = (input: unknown): input is AbortController => {
  */
 export type ConnectUpdater<O extends DescMessage> =
   | MessageInitShape<O>
-  | MessageShape<O>
   | undefined
   | ((prev?: MessageShape<O>) => MessageShape<O> | undefined);
 

--- a/packages/connect-query/src/utils.ts
+++ b/packages/connect-query/src/utils.ts
@@ -17,7 +17,7 @@ import type {
   MessageInitShape,
   MessageShape,
 } from "@bufbuild/protobuf";
-import { create } from "@bufbuild/protobuf";
+import { create, isMessage } from "@bufbuild/protobuf";
 
 import type { MethodUnaryDescriptor } from "./method-unary-descriptor.js";
 
@@ -56,25 +56,27 @@ export const isAbortController = (input: unknown): input is AbortController => {
  */
 export type ConnectUpdater<O extends DescMessage> =
   | MessageInitShape<O>
-  | ((prev?: MessageShape<O>) => MessageInitShape<O> | undefined);
+  | MessageShape<O>
+  | undefined
+  | ((prev?: MessageShape<O>) => MessageShape<O> | undefined);
 
 /**
- * This helper makes sure that the Class for the original data is returned, even if what's provided is a partial message or a plain JavaScript object representing the underlying values.
+ * This helper makes sure that the type for the original response message is returned.
  */
 export const createProtobufSafeUpdater =
-  <I extends DescMessage, O extends DescMessage>(
-    schema: Pick<MethodUnaryDescriptor<I, O>, "output">,
+  <O extends DescMessage>(
+    schema: Pick<MethodUnaryDescriptor<never, O>, "output">,
     updater: ConnectUpdater<O>,
   ) =>
-  (prev?: MessageShape<O>): MessageShape<O> => {
-    if (typeof updater === "function") {
-      return create(
-        schema.output,
-        (
-          updater as (prev?: MessageShape<O>) => MessageInitShape<O> | undefined
-        )(prev),
-      );
+  (prev?: MessageShape<O>): MessageShape<O> | undefined => {
+    if (typeof updater !== "function") {
+      if (updater === undefined) {
+        return undefined;
+      }
+      if (isMessage(updater, schema.output)) {
+        return updater;
+      }
+      return create(schema.output, updater);
     }
-
-    return create(schema.output, updater);
+    return updater(prev);
   };


### PR DESCRIPTION
Closes #446. The signature of the provided updater function is changed to return a message instead of a message init shape.
