### PR TITLE
V2: Enforce cardinality as required prop for key

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,11 +281,11 @@ import { ElizaService } from "./gen/eliza_pb";
 
 const myTransport = useTransport();
 const queryKey = createConnectQueryKey({
-  // The schema is the only required parameter.
   schema: ElizaService.method.say,
   transport: myTransport,
   // You can provide a partial message here.
   input: { sentence: "hello" },
+  // This defines what kind of request it is (either for an infinite or finite query).
   cardinality: "finite",
 });
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ function useQuery<
 >(
   schema: DescMethodUnary<I, O>,
   input?: SkipToken | MessageInitShape<I>,
-  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {},
+  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {}
 ): UseQueryResult<SelectOutData, ConnectError>;
 ```
 
@@ -232,7 +232,7 @@ function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: UseInfiniteQueryOptions<I, O, ParamKey>,
+  }: UseInfiniteQueryOptions<I, O, ParamKey>
 ): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError>;
 ```
 
@@ -249,7 +249,7 @@ Identical to useInfiniteQuery but mapping to the `useSuspenseInfiniteQuery` hook
 ```ts
 function useMutation<I extends DescMessage, O extends DescMessage>(
   schema: DescMethodUnary<I, O>,
-  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {},
+  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {}
 ): UseMutationResult<MessageShape<O>, ConnectError, PartialMessage<I>>;
 ```
 
@@ -261,7 +261,7 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 
 ```ts
 function createConnectQueryKey<Desc extends DescMethod | DescService>(
-  params: KeyParams<Desc>,
+  params: KeyParams<Desc>
 ): ConnectQueryKey;
 ```
 
@@ -286,6 +286,7 @@ const queryKey = createConnectQueryKey({
   transport: myTransport,
   // You can provide a partial message here.
   input: { sentence: "hello" },
+  cardinality: "finite",
 });
 
 // queryKey:
@@ -309,6 +310,7 @@ import { ElizaService } from "./gen/eliza_pb";
 
 const queryKey = createConnectQueryKey({
   schema: ElizaService,
+  cardinality: "finite",
 });
 
 // queryKey:
@@ -346,7 +348,7 @@ function callUnaryMethod<I extends DescMessage, O extends DescMessage>(
   input: MessageInitShape<I> | undefined,
   options?: {
     signal?: AbortSignal;
-  },
+  }
 ): Promise<O>;
 ```
 
@@ -369,6 +371,7 @@ queryClient.setQueryData(
     schema: example,
     transport,
     input: {},
+    cardinality: "finite",
   }),
   createProtobufSafeUpdater(example, (prev) => {
     if (prev === undefined) {
@@ -393,7 +396,7 @@ function createQueryOptions<I extends DescMessage, O extends DescMessage>(
     transport,
   }: {
     transport: Transport;
-  },
+  }
 ): {
   queryKey: ConnectQueryKey;
   queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey> | SkipToken;
@@ -436,7 +439,7 @@ function createInfiniteQueryOptions<
     transport,
     getNextPageParam,
     pageParamKey,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey>
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,
@@ -470,7 +473,7 @@ const transport = addStaticKeyToTransport(
   createConnectTransport({
     baseUrl: "https://demo.connectrpc.com",
   }),
-  "demo",
+  "demo"
 );
 ```
 
@@ -606,6 +609,7 @@ function prefetch() {
       schema: say,
       transport: myTransport,
       input: { sentence: "Hello" },
+      cardinality: "finite",
     }),
     queryFn: () => callUnaryMethod(myTransport, say, { sentence: "Hello" }),
   });

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ function useQuery<
 >(
   schema: DescMethodUnary<I, O>,
   input?: SkipToken | MessageInitShape<I>,
-  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {}
+  { transport, ...queryOptions }: UseQueryOptions<I, O, SelectOutData> = {},
 ): UseQueryResult<SelectOutData, ConnectError>;
 ```
 
@@ -232,7 +232,7 @@ function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: UseInfiniteQueryOptions<I, O, ParamKey>
+  }: UseInfiniteQueryOptions<I, O, ParamKey>,
 ): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError>;
 ```
 
@@ -249,7 +249,7 @@ Identical to useInfiniteQuery but mapping to the `useSuspenseInfiniteQuery` hook
 ```ts
 function useMutation<I extends DescMessage, O extends DescMessage>(
   schema: DescMethodUnary<I, O>,
-  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {}
+  { transport, ...queryOptions }: UseMutationOptions<I, O, Ctx> = {},
 ): UseMutationResult<MessageShape<O>, ConnectError, PartialMessage<I>>;
 ```
 
@@ -261,7 +261,7 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 
 ```ts
 function createConnectQueryKey<Desc extends DescMethod | DescService>(
-  params: KeyParams<Desc>
+  params: KeyParams<Desc>,
 ): ConnectQueryKey;
 ```
 
@@ -348,7 +348,7 @@ function callUnaryMethod<I extends DescMessage, O extends DescMessage>(
   input: MessageInitShape<I> | undefined,
   options?: {
     signal?: AbortSignal;
-  }
+  },
 ): Promise<O>;
 ```
 
@@ -396,7 +396,7 @@ function createQueryOptions<I extends DescMessage, O extends DescMessage>(
     transport,
   }: {
     transport: Transport;
-  }
+  },
 ): {
   queryKey: ConnectQueryKey;
   queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey> | SkipToken;
@@ -439,7 +439,7 @@ function createInfiniteQueryOptions<
     transport,
     getNextPageParam,
     pageParamKey,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey>
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey>,
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,
@@ -473,7 +473,7 @@ const transport = addStaticKeyToTransport(
   createConnectTransport({
     baseUrl: "https://demo.connectrpc.com",
   }),
-  "demo"
+  "demo",
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ npm install @connectrpc/connect-query @connectrpc/connect-web
 ```
 
 > [!TIP]
-> 
+>
 > If you are using something that doesn't automatically install peerDependencies (npm older than v7), you'll want to make sure you also have `@bufbuild/protobuf`, `@connectrpc/connect`, and `@tanstack/react-query` installed. `@connectrpc/connect-web` is required for defining
-the transport to be used by the client.
+> the transport to be used by the client.
 
 ### Usage
 
@@ -106,8 +106,8 @@ export declare const ElizaService: GenService<{
     methodKind: "unary";
     input: typeof SayRequestSchema;
     output: typeof SayResponseSchema;
-  },
-}>
+  };
+}>;
 ```
 
 [`protoc-gen-connect-query`](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-query) is an optional additional plugin that exports every RPC individually for convenience:
@@ -120,7 +120,7 @@ import { ElizaService } from "./eliza_pb";
  *
  * @generated from rpc connectrpc.eliza.v1.ElizaService.Say
  */
-export const say: typeof ElizaService["method"]["say"];
+export const say: (typeof ElizaService)["method"]["say"];
 ```
 
 For more information on code generation, see the [documentation for `protoc-gen-connect-query`](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-query) and the [documentation for `protoc-gen-es`](https://www.npmjs.com/package/@bufbuild/protoc-gen-es).
@@ -268,6 +268,7 @@ function createConnectQueryKey<Desc extends DescMethod | DescService>(
 This function is used under the hood of `useQuery` and other hooks to compute a [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) for TanStack Query. You can use it to create (partial) keys yourself to filter queries.
 
 `useQuery` creates a query key with the following parameters:
+
 1. The qualified name of the RPC.
 2. The transport being used.
 3. The request message.
@@ -280,7 +281,7 @@ import { ElizaService } from "./gen/eliza_pb";
 
 const myTransport = useTransport();
 const queryKey = createConnectQueryKey({
-  // The schema is the only required parameter. 
+  // The schema is the only required parameter.
   schema: ElizaService.method.say,
   transport: myTransport,
   // You can provide a partial message here.
@@ -289,15 +290,15 @@ const queryKey = createConnectQueryKey({
 
 // queryKey:
 [
-  "conect-query",
+  "connect-query",
   {
     transport: "t1",
     serviceName: "connectrpc.eliza.v1.ElizaService",
     methodName: "Say",
     input: { sentence: "hello" },
     cardinality: "finite",
-  }
-]
+  },
+];
 ```
 
 You can create a partial key that matches all RPCs of a service:
@@ -312,12 +313,12 @@ const queryKey = createConnectQueryKey({
 
 // queryKey:
 [
-  "conect-query",
+  "connect-query",
   {
     serviceName: "connectrpc.eliza.v1.ElizaService",
     cardinality: "finite",
-  }
-]
+  },
+];
 ```
 
 Infinite queries have distinct keys. To create a key for an infinite query, use the parameter `cardinality`:
@@ -330,7 +331,7 @@ import { ListService } from "./gen/list_pb";
 // and passes on the pageParamKey.
 const queryKey = createConnectQueryKey({
   schema: ListService.method.list,
-  cardinality: "infinite", // "any" matches infinite and finite queries
+  cardinality: "infinite",
   pageParamKey: "page",
   input: { preview: true },
 });
@@ -520,12 +521,11 @@ TanStack Query manages query caching for you based on query keys. [`QueryKey`s](
       sentence: "hello there",
     },
     cardinality: "finite",
-  }
-]
+  },
+];
 ```
 
 The factory [`createConnectQueryKey`](#createconnectquerykey) makes it easy to create a `ConnectQueryKey`, including partial keys for query filters.
-
 
 ## Testing
 
@@ -615,7 +615,6 @@ function prefetch() {
 > [!TIP]
 >
 > Transports are taken into consideration when building query keys. If you want to prefetch queries on the server, and hydrate them in the client, make sure to use the same transport key on both sides with [`addStaticKeyToTransport`](#addstatickeytotransport).
-
 
 ### What about Streaming?
 

--- a/packages/connect-query/src/call-unary-method.test.ts
+++ b/packages/connect-query/src/call-unary-method.test.ts
@@ -41,6 +41,7 @@ describe("callUnaryMethod", () => {
               schema: ElizaService.method.say,
               input,
               transport,
+              cardinality: "finite",
             }),
             queryFn: async ({
               signal,

--- a/packages/connect-query/src/connect-query-key.test.ts
+++ b/packages/connect-query/src/connect-query-key.test.ts
@@ -38,6 +38,7 @@ describe("createConnectQueryKey", () => {
       transport: fakeTransport,
       schema: ElizaService.method.say,
       input: create(SayRequestSchema, { sentence: "hi" }),
+      cardinality: "finite",
     });
     expect(key).toStrictEqual([
       "connect-query",
@@ -75,6 +76,7 @@ describe("createConnectQueryKey", () => {
     const key = createConnectQueryKey({
       schema: ElizaService.method.say,
       input: undefined,
+      cardinality: "finite",
     });
     expect(key[1].input).toBeUndefined();
   });
@@ -82,6 +84,7 @@ describe("createConnectQueryKey", () => {
   it("allows to omit input", () => {
     const key = createConnectQueryKey({
       schema: ElizaService.method.say,
+      cardinality: "finite",
     });
     expect(key[1].input).toBeUndefined();
   });
@@ -90,15 +93,9 @@ describe("createConnectQueryKey", () => {
     const key = createConnectQueryKey({
       schema: ElizaService.method.say,
       input: skipToken,
+      cardinality: "finite",
     });
     expect(key[1].input).toBe("skipped");
-  });
-
-  it("sets cardinality finite by default", () => {
-    const key = createConnectQueryKey({
-      schema: ElizaService.method.say,
-    });
-    expect(key[1].cardinality).toBe("finite");
   });
 
   it("allows to set cardinality: finite", () => {
@@ -109,10 +106,10 @@ describe("createConnectQueryKey", () => {
     expect(key[1].cardinality).toBe("finite");
   });
 
-  it("allows to set cardinality: any", () => {
+  it("allows to set cardinality: undefined", () => {
     const key = createConnectQueryKey({
       schema: ElizaService.method.say,
-      cardinality: "any",
+      cardinality: undefined,
     });
     expect(key[1].cardinality).toBeUndefined();
   });
@@ -120,6 +117,7 @@ describe("createConnectQueryKey", () => {
   it("allows to set a service schema", () => {
     const key = createConnectQueryKey({
       schema: ElizaService,
+      cardinality: "finite",
     });
     expect(key[1].serviceName).toBe(ElizaService.typeName);
     expect(key[1].methodName).toBeUndefined();

--- a/packages/connect-query/src/connect-query-key.ts
+++ b/packages/connect-query/src/connect-query-key.ts
@@ -68,7 +68,7 @@ export type ConnectQueryKey = [
     /**
      * Whether this is an infinite query, or a regular one.
      */
-    cardinality?: "infinite" | "finite";
+    cardinality?: "infinite" | "finite" | undefined;
   },
 ];
 
@@ -90,9 +90,9 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
        */
       transport?: Transport;
       /**
-       * Set `cardinality` in the key - "finite" by default.
+       * Set `cardinality` in the key - undefined is used for filters to match both finite and infinite queries.
        */
-      cardinality?: "finite" | "infinite" | "any";
+      cardinality: "finite" | "infinite" | undefined;
       /**
        * If omit the field with this name from the key for infinite queries.
        */
@@ -108,9 +108,9 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
        */
       transport?: Transport;
       /**
-       * Set `cardinality` in the key - "finite" by default.
+       * Set `cardinality` in the key - undefined is used for filters to match both finite and infinite queries.
        */
-      cardinality?: "finite" | "infinite" | "any";
+      cardinality: "finite" | "infinite" | undefined;
     };
 
 /**
@@ -166,17 +166,8 @@ export function createConnectQueryKey<
   if (params.transport !== undefined) {
     props.transport = createTransportKey(params.transport);
   }
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- "Cases not matched: undefined" 🤷
-  switch (params.cardinality) {
-    case undefined:
-    case "finite":
-      props.cardinality = "finite";
-      break;
-    case "infinite":
-      props.cardinality = "infinite";
-      break;
-    case "any":
-      break;
+  if (params.cardinality !== undefined) {
+    props.cardinality = params.cardinality;
   }
   if (params.schema.kind == "rpc" && "input" in params) {
     if (typeof params.input == "symbol") {

--- a/packages/connect-query/src/create-query-options.test.ts
+++ b/packages/connect-query/src/create-query-options.test.ts
@@ -37,6 +37,7 @@ describe("createQueryOptions", () => {
       schema: sayMethodDescriptor,
       input: { sentence: "hi" },
       transport: mockedElizaTransport,
+      cardinality: "finite",
     });
     const opt = createQueryOptions(
       sayMethodDescriptor,

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -64,6 +64,7 @@ export function createQueryOptions<
     schema,
     input: input ?? create(schema.input),
     transport,
+    cardinality: "finite",
   });
   const structuralSharing = createStructuralSharing(schema.output);
   const queryFn =

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -258,7 +258,7 @@ describe("useInfiniteQuery", () => {
       queryKey: createConnectQueryKey({
         schema: methodDescriptor,
         transport: mockedPaginatedTransport,
-        cardinality: "any",
+        cardinality: undefined,
         pageParamKey: "page",
         input: {
           page: 0n,


### PR DESCRIPTION
As discussed in [discussion thread](https://github.com/connectrpc/connect-query-es/pull/449#discussion_r1793551960), we need to be explicit about cardinality of query keys.