### PR TITLE
refactor: Maintain consistent naming convention for Options across codebase

### DIFF
--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -56,7 +56,7 @@ export function useQuery<
     callOptions,
   });
   const { enabled: baseEnabled, ...baseRest } = baseOptions;
-  const tsOpts = {
+  const tsOptions = {
     ...queryOptions,
     ...baseRest,
   };
@@ -64,9 +64,9 @@ export function useQuery<
   // incoming query options.
   const enabled = baseEnabled ?? queryOptions.enabled;
   if (enabled !== undefined) {
-    tsOpts.enabled = enabled;
+    tsOptions.enabled = enabled;
   }
-  return tsUseQuery(tsOpts);
+  return tsUseQuery(tsOptions);
 }
 
 /**


### PR DESCRIPTION
While analyzing this library at my new company, I noticed an opportunity for improvement in maintaining consistent naming conventions.

## Changes
- Renamed 'tsOpts' to 'tsOptions' to align with existing naming patterns
- This change ensures consistency with other Options usage

## Why
- Maintains consistent naming convention throughout the codebase
- All other option-related variables already use the full 'Options' suffix
- This change completes the standardization of our options naming pattern