### PR TITLE
V2: Add overload to make sure createQueryOptions only returns skipToken when could be passed skipToken

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,9 @@ const config = {
     "import/resolver": {
       typescript: {},
     },
+    vitest: {
+      typecheck: true,
+    },
   },
   rules: {
     ...vitest.configs.recommended.rules,

--- a/packages/connect-query/src/create-query-options.test.ts
+++ b/packages/connect-query/src/create-query-options.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { skipToken } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { createConnectQueryKey } from "./connect-query-key.js";
 import { createQueryOptions } from "./create-query-options.js";
@@ -31,6 +31,7 @@ describe("createQueryOptions", () => {
       transport: mockedElizaTransport,
     });
     expect(opt.queryFn).toBe(skipToken);
+    expectTypeOf(opt.queryFn).toEqualTypeOf(skipToken);
   });
   it("sets queryKey", () => {
     const want = createConnectQueryKey({

--- a/packages/connect-query/src/create-query-options.ts
+++ b/packages/connect-query/src/create-query-options.ts
@@ -48,6 +48,54 @@ export function createQueryOptions<
   O extends DescMessage,
 >(
   schema: DescMethodUnary<I, O>,
+  input: MessageInitShape<I> | undefined,
+  {
+    transport,
+  }: {
+    transport: Transport;
+  },
+): {
+  queryKey: ConnectQueryKey;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey>;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+};
+export function createQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+>(
+  schema: DescMethodUnary<I, O>,
+  input: SkipToken,
+  {
+    transport,
+  }: {
+    transport: Transport;
+  },
+): {
+  queryKey: ConnectQueryKey;
+  queryFn: SkipToken;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+};
+export function createQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+>(
+  schema: DescMethodUnary<I, O>,
+  input: SkipToken | MessageInitShape<I> | undefined,
+  {
+    transport,
+  }: {
+    transport: Transport;
+  },
+): {
+  queryKey: ConnectQueryKey;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey> | SkipToken;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+};
+export function createQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+>(
+  schema: DescMethodUnary<I, O>,
   input: SkipToken | MessageInitShape<I> | undefined,
   {
     transport,


### PR DESCRIPTION
In order to use createQueryOptions with recent versions of react-query and `useSuspenseQuery`, we need to make sure createQueryOptions isn't passing `skipToken` as a potential type when the input type couldn't be skipToken. This is because the typings for `useSuspenseQuery` now disallow skipping (which was always the case, just was not reflected in the types.)

To fix this, we overload the `createQueryOptions` call to indicate with it's types that it will only return a skipToken when input is a skipToken.