### PR TITLE
V2: Remove queryKeyHashFn to allow default query client access to queries

### DIFF
--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -22,7 +22,6 @@ import type { Transport } from "@connectrpc/connect";
 import type {
   GetNextPageParamFunction,
   QueryFunction,
-  QueryKey,
   SkipToken,
 } from "@tanstack/react-query";
 import { skipToken } from "@tanstack/react-query";
@@ -65,7 +64,7 @@ function createUnaryInfiniteQueryFn<
     pageParamKey,
   }: {
     pageParamKey: ParamKey;
-  },
+  }
 ): QueryFunction<
   MessageShape<O>,
   ConnectQueryKey,
@@ -100,7 +99,7 @@ export function createInfiniteQueryOptions<
     transport,
     getNextPageParam,
     pageParamKey,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport }
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,
@@ -117,7 +116,6 @@ export function createInfiniteQueryOptions<
     | SkipToken;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
   initialPageParam: MessageInitShape<I>[ParamKey];
-  queryKeyHashFn: (queryKey: QueryKey) => string;
 } {
   const queryKey = createConnectQueryKey({
     cardinality: "infinite",
@@ -141,6 +139,5 @@ export function createInfiniteQueryOptions<
     queryKey,
     queryFn,
     structuralSharing,
-    queryKeyHashFn: JSON.stringify,
   };
 }

--- a/packages/connect-query/src/create-infinite-query-options.ts
+++ b/packages/connect-query/src/create-infinite-query-options.ts
@@ -64,7 +64,7 @@ function createUnaryInfiniteQueryFn<
     pageParamKey,
   }: {
     pageParamKey: ParamKey;
-  }
+  },
 ): QueryFunction<
   MessageShape<O>,
   ConnectQueryKey,
@@ -99,7 +99,7 @@ export function createInfiniteQueryOptions<
     transport,
     getNextPageParam,
     pageParamKey,
-  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport }
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
 ): {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,


### PR DESCRIPTION
If we customize the queryKeyHashFn, it prevents `queryClient.setQueryData` from finding the query in question, unless the `queryClient` was initialized with the same queryKeyHashFn. It would be nice to be able to customize this on a per query basis but [it doesn't seem to be an accepted approach](https://github.com/TanStack/query/issues/2352#issuecomment-2422530700).