### PR TITLE
V2: Prepare switch to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <!-- markdownlint-disable-next-line MD041 MD033 -- 033: necessary for setting the width; 041: this is the style of bufbuild READMEs -->
+
+> [!IMPORTANT]  
+> You are looking at the release candidate for version 2. For the current stable version, see the branch [v1](https://github.com/connectrpc/connect-query-es/tree/v1).
+
 <img src="assets/connect-query@16x.png" width="15%" />
 
 <!-- omit in toc -->


### PR DESCRIPTION
This adds a note at the top of the README:

> [!IMPORTANT]  
> You are looking at the release candidate for version 2. For the current stable version, see the branch [v1](https://github.com/connectrpc/connect-query-es/tree/v1).

The plan is to switch the main branch to v2, same as https://github.com/connectrpc/connect-es/pull/1295 and https://github.com/connectrpc/examples-es/pull/2040.

The actual switch is currently blocked by https://github.com/connectrpc/connect-query-es/pull/475.