### PR TITLE
Fix createinfinitequeryoptions skiptoken usage

### DIFF
--- a/packages/connect-query-core/src/create-infinite-query-options.test.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.test.ts
@@ -1,0 +1,35 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { mockEliza } from "test-utils";
+import { ListService } from "test-utils/gen/list_pb.js";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { createInfiniteQueryOptions, skipToken } from "./index.js";
+
+const listMethod = ListService.method.list;
+
+const mockedElizaTransport = mockEliza();
+
+describe("createInfiniteQueryOptions", () => {
+  it("honors skipToken", () => {
+    const opt = createInfiniteQueryOptions(listMethod, skipToken, {
+      transport: mockedElizaTransport,
+      getNextPageParam: (lastPage) => lastPage.page + 1n,
+      pageParamKey: "page",
+    });
+    expect(opt.queryFn).toBe(skipToken);
+    expectTypeOf(opt.queryFn).toEqualTypeOf(skipToken);
+  });
+});

--- a/packages/connect-query-core/src/create-infinite-query-options.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.ts
@@ -92,6 +92,87 @@ export function createInfiniteQueryOptions<
   ParamKey extends keyof MessageInitShape<I>,
 >(
   schema: DescMethodUnary<I, O>,
+  input: MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>,
+  {
+    transport,
+    getNextPageParam,
+    pageParamKey,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
+): {
+  getNextPageParam: ConnectInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey
+  >["getNextPageParam"];
+  queryKey: ConnectQueryKey;
+  queryFn: QueryFunction<
+    MessageShape<O>,
+    ConnectQueryKey,
+    MessageInitShape<I>[ParamKey]
+  >;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+  initialPageParam: MessageInitShape<I>[ParamKey];
+};
+export function createInfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+>(
+  schema: DescMethodUnary<I, O>,
+  input: SkipToken,
+  {
+    transport,
+    getNextPageParam,
+    pageParamKey,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
+): {
+  getNextPageParam: ConnectInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey
+  >["getNextPageParam"];
+  queryKey: ConnectQueryKey;
+  queryFn: SkipToken;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+  initialPageParam: MessageInitShape<I>[ParamKey];
+};
+export function createInfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+>(
+  schema: DescMethodUnary<I, O>,
+  input:
+    | SkipToken
+    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+  {
+    transport,
+    getNextPageParam,
+    pageParamKey,
+  }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
+): {
+  getNextPageParam: ConnectInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey
+  >["getNextPageParam"];
+  queryKey: ConnectQueryKey;
+  queryFn:
+    | QueryFunction<
+        MessageShape<O>,
+        ConnectQueryKey,
+        MessageInitShape<I>[ParamKey]
+      >
+    | SkipToken;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+  initialPageParam: MessageInitShape<I>[ParamKey];
+};
+export function createInfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+>(
+  schema: DescMethodUnary<I, O>,
   input:
     | SkipToken
     | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -362,27 +362,22 @@ describe("useSuspenseInfiniteQuery", () => {
     });
   });
 
-  it("can be disabled without explicit skipToken", () => {
-    const { result } = renderHook(
+  // eslint-disable-next-line vitest/expect-expect -- We are asserting via @ts-expect-error
+  it("can not be disabled with skipToken", () => {
+    renderHook(
       () => {
-        return useInfiniteQuery(
+        return useSuspenseInfiniteQuery(
           methodDescriptor,
-          {
-            page: 0n,
-          },
+          // @ts-expect-error(2345) skipToken is not allowed
+          skipToken,
           {
             getNextPageParam: (lastPage) => lastPage.page + 1n,
             pageParamKey: "page",
-            enabled: false,
           },
         );
       },
       wrapper({}, mockedPaginatedTransport),
     );
-
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.isPending).toBeTruthy();
-    expect(result.current.isFetching).toBeFalsy();
   });
 
   // eslint-disable-next-line vitest/expect-expect -- We are asserting via @ts-expect-error


### PR DESCRIPTION
Similar to #469 , we need to overload createInfiniteQueryOptions so it can work with suspense variants of the most recent version of react-query.