### PR TITLE
Allow omitting cardinality when creating query key

### DIFF
--- a/packages/connect-query-core/src/connect-query-key.ts
+++ b/packages/connect-query-core/src/connect-query-key.ts
@@ -92,7 +92,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
       /**
        * Set `cardinality` in the key - undefined is used for filters to match both finite and infinite queries.
        */
-      cardinality: "finite" | "infinite" | undefined;
+      cardinality?: "finite" | "infinite" | undefined;
       /**
        * If omit the field with this name from the key for infinite queries.
        */
@@ -110,7 +110,7 @@ type KeyParams<Desc extends DescMethod | DescService> = Desc extends DescMethod
       /**
        * Set `cardinality` in the key - undefined is used for filters to match both finite and infinite queries.
        */
-      cardinality: "finite" | "infinite" | undefined;
+      cardinality?: "finite" | "infinite" | undefined;
     };
 
 /**


### PR DESCRIPTION
`cardinality` allows setting `undefined` but requires being set. It seems easier to allow omission for users that don't differentiate between finite and infinite queries in their code