### PR TITLE
Match release process with connect-es

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ git rebase upstream/main
 git checkout -b cool_new_feature
 ```
 
-Make your changes, then ensure that `make` still passes.
+Make your changes, then ensure that `npm run all` still passes.
 When you're satisfied with your changes, push them to your fork.
 
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We'd love your help making `connect-query` better!
+We'd love your help making `connect-query-es` better!
 
 If you'd like to add new exported APIs, please [open an issue][open-issue]
 describing your proposal &mdash; discussing API changes ahead of time makes
@@ -18,40 +18,44 @@ you to sign your commits when you open your pull request, and provide helpful ti
 
 [Fork][fork], then clone the repository:
 
-```bash
+```
 git clone git@github.com:your_github_username/connect-query-es.git
 cd connect-query-es
 git remote add upstream https://github.com/connectrpc/connect-query-es.git
 git fetch upstream
 ```
 
-You will need the latest stable LTS version of Node.js installed.
-
-This project uses `pnpm`. Ensure that you've got corepack enabled with
-`corepack enable`. Any `pnpm` command you run in this project will then use
-the version of `pnpm` pinned in the `packageManager` property in `package.json`.
-
-Make sure that the tests and linters pass:
+Install dependencies (you'll need Node.js in the version specified in `.nvmrc`,
+and `npm` in the version specified in `package.json`):
 
 ```bash
-pnpm run all
+npm ci
 ```
+
+Make sure that the tests, linters, and other checks pass:
+
+```bash
+npm run all
+```
+
+We're using `turborepo` to run tasks. If you haven't used it yet, take a look at
+[filtering and package scoping](https://turbo.build/repo/docs/crafting-your-repository/running-tasks).
 
 ## Making Changes
 
 Start by creating a new branch for your changes:
 
-```bash
+```
 git checkout main
 git fetch upstream
 git rebase upstream/main
 git checkout -b cool_new_feature
 ```
 
-Make your changes, then ensure that `pnpm run all` still passes.
+Make your changes, then ensure that `make` still passes.
 When you're satisfied with your changes, push them to your fork.
 
-```bash
+```
 git commit -a
 git push origin cool_new_feature
 ```
@@ -68,18 +72,6 @@ We're much more likely to approve your changes if you:
 - Add tests for new functionality.
 - Write a [good commit message][commit-message].
 - Maintain backward compatibility.
-
-## Updating dependencies
-
-You can update all dependencies in this project with a single command:
-
-```console
-pnpm run update-all
-```
-
-This command is just a convenience wrapper around `pnpm update` and `pnpm outdated`.
-
-If everything goes as planned, you should not see any output from the `pnpm outdated` command after the update is complete.
 
 [fork]: https://github.com/connectrpc/connect-query-es/fork
 [open-issue]: https://github.com/connectrpc/connect-query-es/issues/new

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -13,23 +13,12 @@
 1. Choose a new version (e.g. 1.2.3), making sure to follow semver. Note that all
    packages in this repository use the same version number.
 2. Make sure you are on the latest main, and create a new git branch.
-3. Set the new version for all packages within the monorepo with the following
-   commands:
-
-   ```bash
-   pnpm --filter "./packages/*" exec pnpm version 1.2.3
-   pnpm run all
-   ```
-
+3. Set the new version across all packages within the monorepo with the following
+   command: `npm run setversion 1.2.3`
 4. Commit, push, and open a pull request with the title "Release 1.2.3".
 5. Edit the PR description with release notes. See the section below for details.
 6. Make sure CI passed on your PR and ask a maintainer for review.
-7. After approval, run the following commands to publish to npmjs.com:
-
-   ```bash
-   pnpm install && pnpm run all && node scripts/release.mjs
-   ```
-
+7. After approval, run the following command to publish to npmjs.com: `npm run release`.
 8. Merge your PR.
 9. Create a new release in the GitHub UI
    - Choose "v1.2.3" as a tag and as the release title.
@@ -39,9 +28,18 @@
 ## Release notes
 
 - We generate release notes with the GitHub feature, see
-  <https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes>
+  https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 - Only changes that impact users should be listed. No need to list things like
   doc changes (unless it’s something major), dependency version bumps, or similar.
   Remove them from the generated release notes.
-- If the release introduces a major new feature or change, add a paragraph at the
-  top that explains it for users.
+- If the release introduces a major new feature or change, add a section at the
+  top that explains it for users. A good example is https://github.com/connectrpc/connect-es/releases/tag/v0.10.0
+  It lists a major new feature and a major change with dedicated sections, and
+  moves the changelist with PR links to a separate "Enhancement" section below.
+- If the release includes a very long list of changes, consider breaking the
+  changelist up with the sections "Enhancements", "Bugfixes", "Breaking changes".
+  A good example is https://github.com/connectrpc/connect-es/releases/tag/v0.9.0
+- If the release includes changes specific to a npm package, group and explain
+  the changelist in according separate sections. A good example is https://github.com/connectrpc/connect-es/releases/tag/v0.8.0
+  Note that we are not using full package names with scope - a more user-friendly
+  name like "Connect for Node.js" or "Connect for Fastify" is preferable.


### PR DESCRIPTION
To better match the release process with connect-es. Left the examples specifically pointing at connect-es tag since we don't really have a good example in connect-query-es.
