### PR TITLE
Ignore vitest generated files in spell checking

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -52,6 +52,7 @@
     "**/gen",
     "**/snapshots",
     "**/*.css",
-    "**/*.xml"
+    "**/*.xml",
+    "**/tsconfig.vitest-temp.json"
   ]
 }


### PR DESCRIPTION
Leaving these causes lint to fail if running concurrently with tests.
