### PR TITLE
Add utility helper to update infinite data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Connect-Query is an wrapper around [TanStack Query](https://tanstack.com/query) 
   - [`createConnectQueryKey`](#createconnectquerykey)
   - [`callUnaryMethod`](#callunarymethod)
   - [`createProtobufSafeUpdater`](#createprotobufsafeupdater)
+  - [`createProtobufSafeInfiniteUpdater`](#createprotobufsafeinfiniteupdater)
   - [`createQueryOptions`](#createqueryoptions)
   - [`createInfiniteQueryOptions`](#createinfinitequeryoptions)
   - [`addStaticKeyToTransport`](#addstatickeytotransport)
@@ -386,6 +387,10 @@ queryClient.setQueryData(
 );
 
 ```
+
+### `createProtobufSafeInfiniteUpdater`
+
+Creates a typesafe updater for infinite queries. Identical to `createProtobufSafeUpdater` except the data recieved must be of the shape expected for infinite data.
 
 ### `createQueryOptions`
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ queryClient.setQueryData(
 
 ### `createProtobufSafeInfiniteUpdater`
 
-Creates a typesafe updater for infinite queries. Identical to `createProtobufSafeUpdater` except the data recieved must be of the shape expected for infinite data.
+Creates a typesafe updater for infinite queries. Identical to `createProtobufSafeUpdater` except the data received must be of the shape expected for infinite data.
 
 ### `createQueryOptions`
 

--- a/packages/connect-query-core/src/utils.test.ts
+++ b/packages/connect-query-core/src/utils.test.ts
@@ -186,7 +186,6 @@ describe("createProtobufSafeUpdater", () => {
   });
 });
 
-
 describe("createProtobufSafeInfiniteUpdater", () => {
   describe("with update message", () => {
     const schema = { output: Proto2MessageSchema };
@@ -247,9 +246,9 @@ describe("createProtobufSafeInfiniteUpdater", () => {
           ...prev.pages,
           {
             int32Field: 33,
-            stringField: "whatever"
-          }
-        ]
+            stringField: "whatever",
+          },
+        ],
       };
     });
     it("accepts undefined", () => {
@@ -259,12 +258,11 @@ describe("createProtobufSafeInfiniteUpdater", () => {
     it("can add a new page", () => {
       const next = safeUpdater({
         pageParams: [],
-        pages: []
+        pages: [],
       });
 
       expect(next?.pageParams).toHaveLength(1);
       expect(next?.pages).toHaveLength(1);
-
-    })
+    });
   });
 });

--- a/packages/connect-query-core/src/utils.test.ts
+++ b/packages/connect-query-core/src/utils.test.ts
@@ -242,13 +242,29 @@ describe("createProtobufSafeInfiniteUpdater", () => {
         return undefined;
       }
       return {
-        ...prev,
-        int32Field: 999,
+        pageParams: [...prev.pageParams, 44],
+        pages: [
+          ...prev.pages,
+          {
+            int32Field: 33,
+            stringField: "whatever"
+          }
+        ]
       };
     });
     it("accepts undefined", () => {
       const next = safeUpdater(undefined);
       expect(next).toBeUndefined();
     });
+    it("can add a new page", () => {
+      const next = safeUpdater({
+        pageParams: [],
+        pages: []
+      });
+
+      expect(next?.pageParams).toHaveLength(1);
+      expect(next?.pages).toHaveLength(1);
+
+    })
   });
 });

--- a/packages/connect-query-core/src/utils.ts
+++ b/packages/connect-query-core/src/utils.ts
@@ -65,7 +65,7 @@ export type ConnectUpdater<O extends DescMessage> =
 export type ConnectInfiniteUpdater<O extends DescMessage> =
   | InfiniteData<MessageInitShape<O>>
   | undefined
-  | ((prev?: InfiniteData<MessageShape<O>>) => InfiniteData<MessageShape<O>> | undefined);
+  | ((prev?: InfiniteData<MessageShape<O>>) => InfiniteData<MessageInitShape<O>> | undefined);
 
 /**
  * This helper makes sure that the type for the original response message is returned.

--- a/packages/connect-query-core/src/utils.ts
+++ b/packages/connect-query-core/src/utils.ts
@@ -65,7 +65,9 @@ export type ConnectUpdater<O extends DescMessage> =
 export type ConnectInfiniteUpdater<O extends DescMessage> =
   | InfiniteData<MessageInitShape<O>>
   | undefined
-  | ((prev?: InfiniteData<MessageShape<O>>) => InfiniteData<MessageInitShape<O>> | undefined);
+  | ((
+      prev?: InfiniteData<MessageShape<O>>,
+    ) => InfiniteData<MessageInitShape<O>> | undefined);
 
 /**
  * This helper makes sure that the type for the original response message is returned.
@@ -88,28 +90,29 @@ export const createProtobufSafeUpdater =
     return updater(prev);
   };
 
-
 export const createProtobufSafeInfiniteUpdater =
-<O extends DescMessage>(
-  schema: Pick<DescMethodUnary<never, O>, "output">,
-  updater: ConnectInfiniteUpdater<O>,
-) =>
-(prev?: InfiniteData<MessageShape<O>>): InfiniteData<MessageShape<O>> | undefined => {
-  if (typeof updater !== "function") {
-    if (updater === undefined) {
+  <O extends DescMessage>(
+    schema: Pick<DescMethodUnary<never, O>, "output">,
+    updater: ConnectInfiniteUpdater<O>,
+  ) =>
+  (
+    prev?: InfiniteData<MessageShape<O>>,
+  ): InfiniteData<MessageShape<O>> | undefined => {
+    if (typeof updater !== "function") {
+      if (updater === undefined) {
+        return undefined;
+      }
+      return {
+        pageParams: updater.pageParams,
+        pages: updater.pages.map((i) => create(schema.output, i)),
+      };
+    }
+    const result = updater(prev);
+    if (result === undefined) {
       return undefined;
     }
     return {
-      pageParams: updater.pageParams,
-      pages: updater.pages.map(i => create(schema.output, i))
-    }
-  }
-  const result = updater(prev);
-  if (result === undefined) {
-    return undefined;
-  }
-  return {
-    pageParams: result.pageParams,
-    pages: result.pages.map(i => create(schema.output, i))
-  }
-};
+      pageParams: result.pageParams,
+      pages: result.pages.map((i) => create(schema.output, i)),
+    };
+  };

--- a/packages/connect-query-core/src/utils.ts
+++ b/packages/connect-query-core/src/utils.ts
@@ -19,6 +19,7 @@ import type {
   MessageShape,
 } from "@bufbuild/protobuf";
 import { create, isMessage } from "@bufbuild/protobuf";
+import type { InfiniteData } from "@tanstack/query-core";
 
 /**
  * Throws an error with the provided message when the condition is `false`
@@ -59,6 +60,14 @@ export type ConnectUpdater<O extends DescMessage> =
   | ((prev?: MessageShape<O>) => MessageShape<O> | undefined);
 
 /**
+ * @see `Updater` from `@tanstack/react-query`
+ */
+export type ConnectInfiniteUpdater<O extends DescMessage> =
+  | InfiniteData<MessageInitShape<O>>
+  | undefined
+  | ((prev?: InfiniteData<MessageShape<O>>) => InfiniteData<MessageShape<O>> | undefined);
+
+/**
  * This helper makes sure that the type for the original response message is returned.
  */
 export const createProtobufSafeUpdater =
@@ -78,3 +87,29 @@ export const createProtobufSafeUpdater =
     }
     return updater(prev);
   };
+
+
+export const createProtobufSafeInfiniteUpdater =
+<O extends DescMessage>(
+  schema: Pick<DescMethodUnary<never, O>, "output">,
+  updater: ConnectInfiniteUpdater<O>,
+) =>
+(prev?: InfiniteData<MessageShape<O>>): InfiniteData<MessageShape<O>> | undefined => {
+  if (typeof updater !== "function") {
+    if (updater === undefined) {
+      return undefined;
+    }
+    return {
+      pageParams: updater.pageParams,
+      pages: updater.pages.map(i => create(schema.output, i))
+    }
+  }
+  const result = updater(prev);
+  if (result === undefined) {
+    return undefined;
+  }
+  return {
+    pageParams: result.pageParams,
+    pages: result.pages.map(i => create(schema.output, i))
+  }
+};


### PR DESCRIPTION
This new API is very similar to `createProtobufSafeUpdater`, just designed to update and validate paginated data.

Fixes #517 