### PR TITLE
Add module federation support by adding package.json export

### DIFF
--- a/packages/connect-query/package.json
+++ b/packages/connect-query/package.json
@@ -27,7 +27,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "@connectrpc/connect-query-core": "^2.0.1"


### PR DESCRIPTION
Hi, I wanted to use connect-query in my microfrontend project which uses Vite Module Federation.
I need to specify connect-query as singleton like this:
```ts
// ...
 shared: {
        react: {
          requiredVersion: dependencies.react,
          singleton: true,
        },
        'react-router': {
          requiredVersion: dependencies['react-router'],
          singleton: true,
        },
        // Important
        '@connectrpc/connect-query': {
          requiredVersion: dependencies['@connectrpc/connect-query'],
          singleton: true
        },
        '@tanstack/react-query': {
          requiredVersion: dependencies['@tanstack/react-query'],
          singleton: true
        },
      },
// ...
```

Without my suggested fix, I get this in the browsers console:
`[ Federation Runtime ] Warn Version 0 from userFrontend of shared singleton module @connectrpc/connect-query does not satisfy the requirement of host which needs ^2.0.1)`

The output of the host/frontend in the console:
```bash
[host@0.0.0](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) dev

vite

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /app/node_modules/@connectrpc/connect-query/package.json
at exportsNotFound (node:internal/modules/esm/resolve:314:10)
at packageExportsResolve (node:internal/modules/esm/resolve:661:9)
at resolveExports (node:internal/modules/cjs/loader:657:36)
at Function._findPath (node:internal/modules/cjs/loader:749:31)
at Function._resolveFilename (node:internal/modules/cjs/loader:1387:27)
at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
at Function._load (node:internal/modules/cjs/loader:1211:37)
at TracingChannel.traceSync (node:diagnostics_channel:322:14)
at wrapModuleLoad (node:internal/modules/cjs/loader:235:24) {
code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

12:06:55 PM [vite] (client) Forced re-optimization of dependencies

VITE v6.3.3 ready in 547 ms

➜ Local: [http://localhost:3000/⁠](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)

➜ Network: [http://172.18.0.7:3000/⁠](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
```

My PR fixes this warning/error.