### PR TITLE
Add datatag to ConnectQueryKey so queryClient can infer type info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 /packages/*/dist
 /packages/*/coverage
+tsconfig.vitest-temp.json

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ import { say } from "./gen/eliza-ElizaService_connectquery";
 
 function prefetch() {
   return queryClient.prefetchQuery(
-    createQueryOptions(say, { sentence: "Hello" }, { transport: myTransport })
+    createQueryOptions(say, { sentence: "Hello" }, { transport: myTransport }),
   );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -260,19 +260,17 @@ Any additional `options` you pass to `useMutation` will be merged with the optio
 
 ### `createConnectQueryKey`
 
-```ts
-function createConnectQueryKey<Desc extends DescMethod | DescService>(
-  params: KeyParams<Desc>,
-): ConnectQueryKey;
-```
-
-This function is used under the hood of `useQuery` and other hooks to compute a [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) for TanStack Query. You can use it to create (partial) keys yourself to filter queries.
+This function is used under the hood of `useQuery` and other hooks to compute a [`queryKey`](https://tanstack.com/query/v4/docs/react/guides/query-keys) for TanStack Query. You can use it to create keys yourself to filter queries.
 
 `useQuery` creates a query key with the following parameters:
 
 1. The qualified name of the RPC.
 2. The transport being used.
 3. The request message.
+4. The cardinality of the RPC (either "finite" or "infinite").
+5. Adds a DataTag which brands the key with the associated data type of the response.
+
+The DataTag type allows @tanstack/react-query functions to properly infer the type of the data returned by the query. This is useful for things like `QueryClient.setQueryData` and `QueryClient.getQueryData`.
 
 To create the same key manually, you simply provide the same parameters:
 
@@ -355,7 +353,7 @@ function callUnaryMethod<I extends DescMessage, O extends DescMessage>(
 
 This API allows you to directly call the method using the provided transport. Use this if you need to manually call a method outside of the context of a React component, or need to call it where you can't use hooks.
 
-### `createProtobufSafeUpdater`
+### `createProtobufSafeUpdater` (deprecated)
 
 Creates a typesafe updater that can be used to update data in a query cache. Used in combination with a queryClient.
 
@@ -386,6 +384,8 @@ queryClient.setQueryData(
 );
 
 ```
+
+** Note: This API is deprecated and will be removed in a future version. `ConnectQueryKey` now contains type information to make it safer to use `setQueryData` directly. **
 
 ### `createQueryOptions`
 
@@ -599,21 +599,15 @@ Connect-Query does require React, but the core (`createConnectQueryKey` and `cal
 
 ### How do I do Prefetching?
 
-When you might not have access to React context, you can use the `create` series of functions and provide a transport directly. For example:
+When you might not have access to React context, you can use `createQueryOptions` and provide a transport directly. For example:
 
 ```ts
 import { say } from "./gen/eliza-ElizaService_connectquery";
 
 function prefetch() {
-  return queryClient.prefetchQuery({
-    queryKey: createConnectQueryKey({
-      schema: say,
-      transport: myTransport,
-      input: { sentence: "Hello" },
-      cardinality: "finite",
-    }),
-    queryFn: () => callUnaryMethod(myTransport, say, { sentence: "Hello" }),
-  });
+  return queryClient.prefetchQuery(
+    createQueryOptions(say, { sentence: "Hello" }, { transport: myTransport })
+  );
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9536,7 +9536,7 @@
       "peerDependencies": {
         "@bufbuild/protobuf": "2.x",
         "@connectrpc/connect": "^2.0.1",
-        "@tanstack/react-query": "5.x",
+        "@tanstack/react-query": ">=5.62.0",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19"
       }
@@ -9560,7 +9560,7 @@
       "peerDependencies": {
         "@bufbuild/protobuf": "2.x",
         "@connectrpc/connect": "^2.0.1",
-        "@tanstack/query-core": "5.x"
+        "@tanstack/query-core": ">=5.62.0"
       }
     },
     "packages/examples/react/basic": {

--- a/packages/connect-query-core/package.json
+++ b/packages/connect-query-core/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "2.x",
     "@connectrpc/connect": "^2.0.1",
-    "@tanstack/query-core": "5.x"
+    "@tanstack/query-core": ">=5.62.0"
   },
   "files": [
     "dist/**"

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -168,7 +168,7 @@ describe("createConnectQueryKey", () => {
     });
     sampleQueryClient.setQueryData(
       key,
-      create(SayResponseSchema, { sentence: "a proper value" })
+      create(SayResponseSchema, { sentence: "a proper value" }),
     );
   });
 
@@ -202,15 +202,10 @@ describe("createConnectQueryKey", () => {
         // @ts-expect-error(2345) $typename is required
         pages: [{ sentence: "a proper value but missing $typename" }],
       });
-      sampleQueryClient.setQueryData(
-        key,
-        {
-          pageParams: [0],
-          pages: [
-            create(SayResponseSchema, { sentence: "a proper value" }),
-          ]
-        }
-      );
+      sampleQueryClient.setQueryData(key, {
+        pageParams: [0],
+        pages: [create(SayResponseSchema, { sentence: "a proper value" })],
+      });
     });
   });
 });

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -17,6 +17,7 @@ import type { Transport } from "@connectrpc/connect";
 import {
   ElizaService,
   SayRequestSchema,
+  SayResponseSchema,
   type SayResponse,
 } from "test-utils/gen/eliza_pb.js";
 import { ListRequestSchema, ListService } from "test-utils/gen/list_pb.js";
@@ -26,7 +27,7 @@ import { createConnectQueryKey } from "./connect-query-key.js";
 import { skipToken } from "./index.js";
 import { createMessageKey } from "./message-key.js";
 import { createTransportKey } from "./transport-key.js";
-import { QueryClient } from "@tanstack/query-core";
+import { type InfiniteData, QueryClient } from "@tanstack/query-core";
 
 describe("createConnectQueryKey", () => {
   const fakeTransport: Transport = {
@@ -116,6 +117,7 @@ describe("createConnectQueryKey", () => {
       schema: ElizaService.method.say,
       cardinality: undefined,
     });
+    // @ts-expect-error(2322) cardinality is type undefined as well as actually undefined
     expect(key[1].cardinality).toBeUndefined();
   });
 
@@ -130,9 +132,9 @@ describe("createConnectQueryKey", () => {
 
   it("cannot except invalid input", () => {
     createConnectQueryKey({
+      // @ts-expect-error(2322) cannot create a key with invalid input
       schema: ElizaService.method.say,
       input: {
-        // @ts-expect-error(2322) cannot create a key with invalid input
         sentence: 1,
       },
       cardinality: undefined,
@@ -149,5 +151,66 @@ describe("createConnectQueryKey", () => {
     const data = sampleQueryClient.getQueryData(key);
 
     expectTypeOf(data).toEqualTypeOf<SayResponse | undefined>();
+  });
+
+  it("supports typesafe data updaters", () => {
+    const sampleQueryClient = new QueryClient();
+    const key = createConnectQueryKey({
+      schema: ElizaService.method.say,
+      input: create(SayRequestSchema, { sentence: "hi" }),
+      cardinality: "finite",
+    });
+    // @ts-expect-error(2345) this is a test to check if the type is correct
+    sampleQueryClient.setQueryData(key, { sentence: 1 });
+    // @ts-expect-error(2345) $typename is required
+    sampleQueryClient.setQueryData(key, {
+      sentence: "a proper value but missing $typename",
+    });
+    sampleQueryClient.setQueryData(
+      key,
+      create(SayResponseSchema, { sentence: "a proper value" })
+    );
+  });
+
+  describe("infinite queries", () => {
+    it("contains type hints to indicate the output type", () => {
+      const sampleQueryClient = new QueryClient();
+      const key = createConnectQueryKey({
+        schema: ElizaService.method.say,
+        input: create(SayRequestSchema, { sentence: "hi" }),
+        cardinality: "infinite",
+      });
+      const data = sampleQueryClient.getQueryData(key);
+
+      expectTypeOf(data).toEqualTypeOf<InfiniteData<SayResponse> | undefined>();
+    });
+
+    it("supports typesafe data updaters", () => {
+      const sampleQueryClient = new QueryClient();
+      const key = createConnectQueryKey({
+        schema: ElizaService.method.say,
+        input: create(SayRequestSchema, { sentence: "hi" }),
+        cardinality: "infinite",
+      });
+      sampleQueryClient.setQueryData(key, {
+        pages: [
+          // @ts-expect-error(2345) make sure the shape is as expected
+          { sentence: 1 },
+        ],
+      });
+      sampleQueryClient.setQueryData(key, {
+        // @ts-expect-error(2345) $typename is required
+        pages: [{ sentence: "a proper value but missing $typename" }],
+      });
+      sampleQueryClient.setQueryData(
+        key,
+        {
+          pageParams: [0],
+          pages: [
+            create(SayResponseSchema, { sentence: "a proper value" }),
+          ]
+        }
+      );
+    });
   });
 });

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -170,6 +170,13 @@ describe("createConnectQueryKey", () => {
       key,
       create(SayResponseSchema, { sentence: "a proper value" }),
     );
+
+    sampleQueryClient.setQueryData(key, (prev) => {
+      expectTypeOf(prev).toEqualTypeOf<SayResponse | undefined>();
+      return create(SayResponseSchema, {
+        sentence: "a proper value",
+      });
+    });
   });
 
   describe("infinite queries", () => {
@@ -205,6 +212,15 @@ describe("createConnectQueryKey", () => {
       sampleQueryClient.setQueryData(key, {
         pageParams: [0],
         pages: [create(SayResponseSchema, { sentence: "a proper value" })],
+      });
+      sampleQueryClient.setQueryData(key, (prev) => {
+        expectTypeOf(prev).toEqualTypeOf<
+          InfiniteData<SayResponse> | undefined
+        >();
+        return {
+          pageParams: [0],
+          pages: [create(SayResponseSchema, { sentence: "a proper value" })],
+        };
       });
     });
   });

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -14,7 +14,11 @@
 
 import { create } from "@bufbuild/protobuf";
 import type { Transport } from "@connectrpc/connect";
-import { ElizaService, SayRequestSchema, type SayResponse } from "test-utils/gen/eliza_pb.js";
+import {
+  ElizaService,
+  SayRequestSchema,
+  type SayResponse,
+} from "test-utils/gen/eliza_pb.js";
 import { ListRequestSchema, ListService } from "test-utils/gen/list_pb.js";
 import { describe, expect, expectTypeOf, it } from "vitest";
 
@@ -143,7 +147,7 @@ describe("createConnectQueryKey", () => {
       cardinality: "finite",
     });
     const data = sampleQueryClient.getQueryData(key);
-    
+
     expectTypeOf(data).toEqualTypeOf<SayResponse | undefined>();
-  })
+  });
 });

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -14,14 +14,15 @@
 
 import { create } from "@bufbuild/protobuf";
 import type { Transport } from "@connectrpc/connect";
-import { ElizaService, SayRequestSchema } from "test-utils/gen/eliza_pb.js";
+import { ElizaService, SayRequestSchema, type SayResponse } from "test-utils/gen/eliza_pb.js";
 import { ListRequestSchema, ListService } from "test-utils/gen/list_pb.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { createConnectQueryKey } from "./connect-query-key.js";
 import { skipToken } from "./index.js";
 import { createMessageKey } from "./message-key.js";
 import { createTransportKey } from "./transport-key.js";
+import { QueryClient } from "@tanstack/query-core";
 
 describe("createConnectQueryKey", () => {
   const fakeTransport: Transport = {
@@ -133,4 +134,16 @@ describe("createConnectQueryKey", () => {
       cardinality: undefined,
     });
   });
+
+  it("contains type hints to indicate the output type", () => {
+    const sampleQueryClient = new QueryClient();
+    const key = createConnectQueryKey({
+      schema: ElizaService.method.say,
+      input: create(SayRequestSchema, { sentence: "hi" }),
+      cardinality: "finite",
+    });
+    const data = sampleQueryClient.getQueryData(key);
+    
+    expectTypeOf(data).toEqualTypeOf<SayResponse | undefined>();
+  })
 });

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -117,7 +117,6 @@ describe("createConnectQueryKey", () => {
       schema: ElizaService.method.say,
       cardinality: undefined,
     });
-    // @ts-expect-error(2322) cardinality is type undefined as well as actually undefined
     expect(key[1].cardinality).toBeUndefined();
   });
 

--- a/packages/connect-query-core/src/connect-query-key.ts
+++ b/packages/connect-query-core/src/connect-query-key.ts
@@ -45,35 +45,40 @@ import { createTransportKey } from "./transport-key.js";
  *   }
  * ]
  */
-export type ConnectQueryKey<OutputMessage extends DescMessage> = DataTag<[
-  /**
-   * To distinguish Connect query keys from other query keys, they always start with the string "connect-query".
-   */
-  "connect-query",
-  {
-    /**
-     * A key for a Transport reference, created with createTransportKey().
-     */
-    transport?: string;
-    /**
-     * The name of the service, e.g. connectrpc.eliza.v1.ElizaService
-     */
-    serviceName: string;
-    /**
-     * The name of the method, e.g. Say.
-     */
-    methodName?: string;
-    /**
-     * A key for the request message, created with createMessageKey(),
-     * or "skipped".
-     */
-    input?: Record<string, unknown> | "skipped";
-    /**
-     * Whether this is an infinite query, or a regular one.
-     */
-    cardinality?: "infinite" | "finite" | undefined;
-  },
-], MessageShape<OutputMessage>, ConnectError>;
+export type ConnectQueryKey<OutputMessage extends DescMessage = DescMessage> =
+  DataTag<
+    [
+      /**
+       * To distinguish Connect query keys from other query keys, they always start with the string "connect-query".
+       */
+      "connect-query",
+      {
+        /**
+         * A key for a Transport reference, created with createTransportKey().
+         */
+        transport?: string;
+        /**
+         * The name of the service, e.g. connectrpc.eliza.v1.ElizaService
+         */
+        serviceName: string;
+        /**
+         * The name of the method, e.g. Say.
+         */
+        methodName?: string;
+        /**
+         * A key for the request message, created with createMessageKey(),
+         * or "skipped".
+         */
+        input?: Record<string, unknown> | "skipped";
+        /**
+         * Whether this is an infinite query, or a regular one.
+         */
+        cardinality?: "infinite" | "finite" | undefined;
+      },
+    ],
+    MessageShape<OutputMessage>,
+    ConnectError
+  >;
 
 type KeyParamsForMethod<Desc extends DescMethod> = {
   /**
@@ -159,8 +164,7 @@ export function createConnectQueryKey<
   Desc extends DescService,
 >(
   params: KeyParamsForMethod<DescMethodUnary<I, O>> | KeyParamsForService<Desc>,
-): ConnectQueryKey<O>
- {
+): ConnectQueryKey<O> {
   const props: ConnectQueryKey<O>[1] =
     params.schema.kind == "rpc"
       ? {

--- a/packages/connect-query-core/src/connect-query-key.ts
+++ b/packages/connect-query-core/src/connect-query-key.ts
@@ -180,7 +180,7 @@ export function createConnectQueryKey<
 >(
   params: KeyParamsForMethod<DescMethodUnary<I, O>> & {
     cardinality: "finite";
-  }
+  },
 ): FiniteConnectQueryKey<O>;
 export function createConnectQueryKey<
   I extends DescMessage,
@@ -188,7 +188,7 @@ export function createConnectQueryKey<
 >(
   params: KeyParamsForMethod<DescMethodUnary<I, O>> & {
     cardinality: "infinite";
-  }
+  },
 ): InfiniteConnectQueryKey<O>;
 export function createConnectQueryKey<
   I extends DescMessage,
@@ -196,7 +196,7 @@ export function createConnectQueryKey<
 >(
   params: KeyParamsForMethod<DescMethodUnary<I, O>> & {
     cardinality: undefined;
-  }
+  },
 ): ConnectQueryKey<O>;
 export function createConnectQueryKey<
   O extends DescMessage,
@@ -207,7 +207,7 @@ export function createConnectQueryKey<
   O extends DescMessage,
   Desc extends DescService,
 >(
-  params: KeyParamsForMethod<DescMethodUnary<I, O>> | KeyParamsForService<Desc>
+  params: KeyParamsForMethod<DescMethodUnary<I, O>> | KeyParamsForService<Desc>,
 ): ConnectQueryKey<O> {
   const props: {
     serviceName: string;
@@ -237,7 +237,7 @@ export function createConnectQueryKey<
       props.input = createMessageKey(
         params.schema.input,
         params.input,
-        params.pageParamKey
+        params.pageParamKey,
       );
     }
   }

--- a/packages/connect-query-core/src/connect-query-key.ts
+++ b/packages/connect-query-core/src/connect-query-key.ts
@@ -94,7 +94,12 @@ type FiniteConnectQueryKey<OutputMessage extends DescMessage = DescMessage> =
 export type ConnectQueryKey<OutputMessage extends DescMessage = DescMessage> =
   | InfiniteConnectQueryKey<OutputMessage>
   | FiniteConnectQueryKey<OutputMessage>
-  | ["connect-query", SharedConnectQueryOptions];
+  | [
+      "connect-query",
+      SharedConnectQueryOptions & {
+        cardinality: undefined;
+      },
+    ];
 
 type KeyParamsForMethod<Desc extends DescMethod> = {
   /**

--- a/packages/connect-query-core/src/connect-query-key.ts
+++ b/packages/connect-query-core/src/connect-query-key.ts
@@ -18,9 +18,10 @@ import type {
   DescMethodUnary,
   DescService,
   MessageInitShape,
+  MessageShape,
 } from "@bufbuild/protobuf";
-import type { Transport } from "@connectrpc/connect";
-import type { SkipToken } from "@tanstack/query-core";
+import type { ConnectError, Transport } from "@connectrpc/connect";
+import type { DataTag, SkipToken } from "@tanstack/query-core";
 
 import { createMessageKey } from "./message-key.js";
 import { createTransportKey } from "./transport-key.js";
@@ -44,7 +45,7 @@ import { createTransportKey } from "./transport-key.js";
  *   }
  * ]
  */
-export type ConnectQueryKey = [
+export type ConnectQueryKey<OutputMessage extends DescMessage> = DataTag<[
   /**
    * To distinguish Connect query keys from other query keys, they always start with the string "connect-query".
    */
@@ -72,7 +73,7 @@ export type ConnectQueryKey = [
      */
     cardinality?: "infinite" | "finite" | undefined;
   },
-];
+], MessageShape<OutputMessage>, ConnectError>;
 
 type KeyParamsForMethod<Desc extends DescMethod> = {
   /**
@@ -158,8 +159,9 @@ export function createConnectQueryKey<
   Desc extends DescService,
 >(
   params: KeyParamsForMethod<DescMethodUnary<I, O>> | KeyParamsForService<Desc>,
-): ConnectQueryKey {
-  const props: ConnectQueryKey[1] =
+): ConnectQueryKey<O>
+ {
+  const props: ConnectQueryKey<O>[1] =
     params.schema.kind == "rpc"
       ? {
           serviceName: params.schema.parent.typeName,
@@ -185,5 +187,5 @@ export function createConnectQueryKey<
       );
     }
   }
-  return ["connect-query", props];
+  return ["connect-query", props] as ConnectQueryKey<O>;
 }

--- a/packages/connect-query-core/src/create-infinite-query-options.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.ts
@@ -67,7 +67,7 @@ function createUnaryInfiniteQueryFn<
   },
 ): QueryFunction<
   MessageShape<O>,
-  ConnectQueryKey,
+  ConnectQueryKey<O>,
   MessageInitShape<I>[ParamKey]
 > {
   return async (context) => {
@@ -104,10 +104,10 @@ export function createInfiniteQueryOptions<
     O,
     ParamKey
   >["getNextPageParam"];
-  queryKey: ConnectQueryKey;
+  queryKey: ConnectQueryKey<O>;
   queryFn: QueryFunction<
     MessageShape<O>,
-    ConnectQueryKey,
+    ConnectQueryKey<O>,
     MessageInitShape<I>[ParamKey]
   >;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
@@ -131,7 +131,7 @@ export function createInfiniteQueryOptions<
     O,
     ParamKey
   >["getNextPageParam"];
-  queryKey: ConnectQueryKey;
+  queryKey: ConnectQueryKey<O>;
   queryFn: SkipToken;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
   initialPageParam: MessageInitShape<I>[ParamKey];
@@ -156,11 +156,11 @@ export function createInfiniteQueryOptions<
     O,
     ParamKey
   >["getNextPageParam"];
-  queryKey: ConnectQueryKey;
+  queryKey: ConnectQueryKey<O>;
   queryFn:
     | QueryFunction<
         MessageShape<O>,
-        ConnectQueryKey,
+        ConnectQueryKey<O>,
         MessageInitShape<I>[ParamKey]
       >
     | SkipToken;
@@ -187,11 +187,11 @@ export function createInfiniteQueryOptions<
     O,
     ParamKey
   >["getNextPageParam"];
-  queryKey: ConnectQueryKey;
+  queryKey: ConnectQueryKey<O>;
   queryFn:
     | QueryFunction<
         MessageShape<O>,
-        ConnectQueryKey,
+        ConnectQueryKey<O>,
         MessageInitShape<I>[ParamKey]
       >
     | SkipToken;

--- a/packages/connect-query-core/src/create-query-options.ts
+++ b/packages/connect-query-core/src/create-query-options.ts
@@ -32,7 +32,7 @@ function createUnaryQueryFn<I extends DescMessage, O extends DescMessage>(
   transport: Transport,
   schema: DescMethodUnary<I, O>,
   input: MessageInitShape<I> | undefined,
-): QueryFunction<MessageShape<O>, ConnectQueryKey> {
+): QueryFunction<MessageShape<O>, ConnectQueryKey<O>> {
   return async (context) => {
     return callUnaryMethod(transport, schema, input, {
       signal: context.signal,
@@ -55,8 +55,8 @@ export function createQueryOptions<
     transport: Transport;
   },
 ): {
-  queryKey: ConnectQueryKey;
-  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey>;
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>>;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
 };
 export function createQueryOptions<
@@ -71,7 +71,7 @@ export function createQueryOptions<
     transport: Transport;
   },
 ): {
-  queryKey: ConnectQueryKey;
+  queryKey: ConnectQueryKey<O>;
   queryFn: SkipToken;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
 };
@@ -87,8 +87,8 @@ export function createQueryOptions<
     transport: Transport;
   },
 ): {
-  queryKey: ConnectQueryKey;
-  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey> | SkipToken;
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>> | SkipToken;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
 };
 export function createQueryOptions<
@@ -103,8 +103,8 @@ export function createQueryOptions<
     transport: Transport;
   },
 ): {
-  queryKey: ConnectQueryKey;
-  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey> | SkipToken;
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>> | SkipToken;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
 } {
   const queryKey = createConnectQueryKey({

--- a/packages/connect-query-core/src/utils.ts
+++ b/packages/connect-query-core/src/utils.ts
@@ -60,7 +60,7 @@ export type ConnectUpdater<O extends DescMessage> =
 
 /**
  * This helper makes sure that the type for the original response message is returned.
- * 
+ *
  * @deprecated the ConnectQueryKey type now links to the return data type so `setQueryData` can be called safely without this helper.
  */
 export const createProtobufSafeUpdater =

--- a/packages/connect-query-core/src/utils.ts
+++ b/packages/connect-query-core/src/utils.ts
@@ -60,6 +60,8 @@ export type ConnectUpdater<O extends DescMessage> =
 
 /**
  * This helper makes sure that the type for the original response message is returned.
+ * 
+ * @deprecated the ConnectQueryKey type now links to the return data type so `setQueryData` can be called safely without this helper.
  */
 export const createProtobufSafeUpdater =
   <O extends DescMessage>(

--- a/packages/connect-query/package.json
+++ b/packages/connect-query/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "@bufbuild/protobuf": "2.x",
     "@connectrpc/connect": "^2.0.1",
-    "@tanstack/react-query": "5.x",
+    "@tanstack/react-query": ">=5.62.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -52,7 +52,7 @@ export type UseInfiniteQueryOptions<
     ConnectError,
     InfiniteData<MessageShape<O>>,
     MessageShape<O>,
-    ConnectQueryKey,
+    ConnectQueryKey<O>,
     MessageInitShape<I>[ParamKey]
   >,
   "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
@@ -106,7 +106,7 @@ export type UseSuspenseInfiniteQueryOptions<
     ConnectError,
     InfiniteData<MessageShape<O>>,
     MessageShape<O>,
-    ConnectQueryKey,
+    ConnectQueryKey<O>,
     MessageInitShape<I>[ParamKey]
   >,
   "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"

--- a/packages/connect-query/src/use-query.ts
+++ b/packages/connect-query/src/use-query.ts
@@ -48,7 +48,7 @@ export type UseQueryOptions<
     MessageShape<O>,
     ConnectError,
     SelectOutData,
-    ConnectQueryKey
+    ConnectQueryKey<O>
   >,
   "queryFn" | "queryKey"
 > & {
@@ -89,7 +89,7 @@ export type UseSuspenseQueryOptions<
     MessageShape<O>,
     ConnectError,
     SelectOutData,
-    ConnectQueryKey
+    ConnectQueryKey<O>
   >,
   "queryFn" | "queryKey"
 > & {


### PR DESCRIPTION
By adding DataTag annotations to the ConnectQueryKey, QueryClient methods can now infer the return type when calling things like `getQueryData` or `invalidateQueries`.

This is at least a partial alternative to #468 which provides better inference abilities while keeping our api surface smaller. There may still be value down the line with very well defined query client methods but I suspect this change covers 90% of the current use cases.