### PR TITLE
Export QueryOptions and similar types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Connect-Query is an wrapper around [TanStack Query](https://tanstack.com/query) 
   - [`createInfiniteQueryOptions`](#createinfinitequeryoptions)
   - [`addStaticKeyToTransport`](#addstatickeytotransport)
   - [`ConnectQueryKey`](#connectquerykey)
+  - [`QueryOptions`](#queryoptions)
+  - [`QueryOptionsWithSkipToken`](#queryoptionswithskiptoken)
+  - [`InfiniteQueryOptions`](#infinitequeryoptions)
+  - [`InfiniteQueryOptionsWithSkipToken`](#infinitequeryoptionswithskiptoken)
 
 ## Quickstart
 
@@ -530,6 +534,71 @@ TanStack Query manages query caching for you based on query keys. [`QueryKey`s](
 ```
 
 The factory [`createConnectQueryKey`](#createconnectquerykey) makes it easy to create a `ConnectQueryKey`, including partial keys for query filters.
+
+### `QueryOptions`
+
+Return type of `createQueryOptions` assuming SkipToken was not provided.
+
+```ts
+interface QueryOptions<I extends DescMessage, O extends DescMessage> {
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>, MessageShape<I>>;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+}
+```
+
+### `QueryOptionsWithSkipToken`
+
+Return type of `createQueryOptions` when SkipToken is provided.
+
+```ts
+interface QueryOptionsWithSkipToken<
+  I extends DescMessage,
+  O extends DescMessage,
+> extends Omit<QueryOptions<I, O>, "queryFn"> {
+  queryFn: SkipToken;
+}
+```
+
+### `InfiniteQueryOptions`
+
+Return type of `createInfiniteQueryOptions` assuming SkipToken was not provided.
+
+```ts
+interface InfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+> {
+  getNextPageParam: ConnectInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey
+  >["getNextPageParam"];
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<
+    MessageShape<O>,
+    ConnectQueryKey<O>,
+    MessageInitShape<I>[ParamKey]
+  >;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+  initialPageParam: MessageInitShape<I>[ParamKey];
+}
+```
+
+### `InfiniteQueryOptionsWithSkipToken`
+
+Return type of `createInfiniteQueryOptions` when SkipToken is provided.
+
+```ts
+interface InfiniteQueryOptionsWithSkipToken<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+> extends Omit<InfiniteQueryOptions<I, O, ParamKey>, "queryFn"> {
+  queryFn: SkipToken;
+}
+```
 
 ## Testing
 

--- a/packages/connect-query-core/src/create-infinite-query-options.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.ts
@@ -35,6 +35,40 @@ import { createStructuralSharing } from "./structural-sharing.js";
 import { assert } from "./utils.js";
 
 /**
+ * Return type of createInfiniteQueryOptions assuming SkipToken was not provided.
+ */
+export interface InfiniteQueryOptions<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+> {
+  getNextPageParam: ConnectInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey
+  >["getNextPageParam"];
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<
+    MessageShape<O>,
+    ConnectQueryKey<O>,
+    MessageInitShape<I>[ParamKey]
+  >;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+  initialPageParam: MessageInitShape<I>[ParamKey];
+}
+
+/**
+ * Return type of createInfiniteQueryOptions when SkipToken is provided
+ */
+export interface InfiniteQueryOptionsWithSkipToken<
+  I extends DescMessage,
+  O extends DescMessage,
+  ParamKey extends keyof MessageInitShape<I>,
+> extends Omit<InfiniteQueryOptions<I, O, ParamKey>, "queryFn"> {
+  queryFn: SkipToken;
+}
+
+/**
  * Options specific to connect-query
  */
 export interface ConnectInfiniteQueryOptions<
@@ -98,21 +132,7 @@ export function createInfiniteQueryOptions<
     getNextPageParam,
     pageParamKey,
   }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
-): {
-  getNextPageParam: ConnectInfiniteQueryOptions<
-    I,
-    O,
-    ParamKey
-  >["getNextPageParam"];
-  queryKey: ConnectQueryKey<O>;
-  queryFn: QueryFunction<
-    MessageShape<O>,
-    ConnectQueryKey<O>,
-    MessageInitShape<I>[ParamKey]
-  >;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-  initialPageParam: MessageInitShape<I>[ParamKey];
-};
+): InfiniteQueryOptions<I, O, ParamKey>;
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
@@ -125,17 +145,7 @@ export function createInfiniteQueryOptions<
     getNextPageParam,
     pageParamKey,
   }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
-): {
-  getNextPageParam: ConnectInfiniteQueryOptions<
-    I,
-    O,
-    ParamKey
-  >["getNextPageParam"];
-  queryKey: ConnectQueryKey<O>;
-  queryFn: SkipToken;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-  initialPageParam: MessageInitShape<I>[ParamKey];
-};
+): InfiniteQueryOptionsWithSkipToken<I, O, ParamKey>;
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
@@ -150,23 +160,9 @@ export function createInfiniteQueryOptions<
     getNextPageParam,
     pageParamKey,
   }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
-): {
-  getNextPageParam: ConnectInfiniteQueryOptions<
-    I,
-    O,
-    ParamKey
-  >["getNextPageParam"];
-  queryKey: ConnectQueryKey<O>;
-  queryFn:
-    | QueryFunction<
-        MessageShape<O>,
-        ConnectQueryKey<O>,
-        MessageInitShape<I>[ParamKey]
-      >
-    | SkipToken;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-  initialPageParam: MessageInitShape<I>[ParamKey];
-};
+):
+  | InfiniteQueryOptions<I, O, ParamKey>
+  | InfiniteQueryOptionsWithSkipToken<I, O, ParamKey>;
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
@@ -181,23 +177,9 @@ export function createInfiniteQueryOptions<
     getNextPageParam,
     pageParamKey,
   }: ConnectInfiniteQueryOptions<I, O, ParamKey> & { transport: Transport },
-): {
-  getNextPageParam: ConnectInfiniteQueryOptions<
-    I,
-    O,
-    ParamKey
-  >["getNextPageParam"];
-  queryKey: ConnectQueryKey<O>;
-  queryFn:
-    | QueryFunction<
-        MessageShape<O>,
-        ConnectQueryKey<O>,
-        MessageInitShape<I>[ParamKey]
-      >
-    | SkipToken;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-  initialPageParam: MessageInitShape<I>[ParamKey];
-} {
+):
+  | InfiniteQueryOptions<I, O, ParamKey>
+  | InfiniteQueryOptionsWithSkipToken<I, O, ParamKey> {
   const queryKey = createConnectQueryKey({
     cardinality: "infinite",
     schema,

--- a/packages/connect-query-core/src/create-query-options.ts
+++ b/packages/connect-query-core/src/create-query-options.ts
@@ -28,6 +28,20 @@ import type { ConnectQueryKey } from "./connect-query-key.js";
 import { createConnectQueryKey } from "./connect-query-key.js";
 import { createStructuralSharing } from "./structural-sharing.js";
 
+/**
+ * Return type of createQueryOptions
+ */
+export interface QueryOptions<O extends DescMessage> {
+  queryKey: ConnectQueryKey<O>;
+  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>>;
+  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
+}
+
+export interface QueryOptionsWithSkipToken<O extends DescMessage>
+  extends Omit<QueryOptions<O>, "queryFn"> {
+  queryFn: SkipToken;
+}
+
 function createUnaryQueryFn<I extends DescMessage, O extends DescMessage>(
   transport: Transport,
   schema: DescMethodUnary<I, O>,
@@ -54,11 +68,7 @@ export function createQueryOptions<
   }: {
     transport: Transport;
   },
-): {
-  queryKey: ConnectQueryKey<O>;
-  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>>;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-};
+): QueryOptions<O>;
 export function createQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
@@ -70,11 +80,7 @@ export function createQueryOptions<
   }: {
     transport: Transport;
   },
-): {
-  queryKey: ConnectQueryKey<O>;
-  queryFn: SkipToken;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-};
+): QueryOptionsWithSkipToken<O>;
 export function createQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
@@ -86,11 +92,7 @@ export function createQueryOptions<
   }: {
     transport: Transport;
   },
-): {
-  queryKey: ConnectQueryKey<O>;
-  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>> | SkipToken;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-};
+): QueryOptions<O> | QueryOptionsWithSkipToken<O>;
 export function createQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
@@ -102,11 +104,7 @@ export function createQueryOptions<
   }: {
     transport: Transport;
   },
-): {
-  queryKey: ConnectQueryKey<O>;
-  queryFn: QueryFunction<MessageShape<O>, ConnectQueryKey<O>> | SkipToken;
-  structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-} {
+): QueryOptions<O> | QueryOptionsWithSkipToken<O> {
   const queryKey = createConnectQueryKey({
     schema,
     input: input ?? create(schema.input),

--- a/packages/connect-query-core/src/index.ts
+++ b/packages/connect-query-core/src/index.ts
@@ -18,8 +18,16 @@ export { createProtobufSafeUpdater } from "./utils.js";
 export type { ConnectUpdater } from "./utils.js";
 export { callUnaryMethod } from "./call-unary-method.js";
 export { createInfiniteQueryOptions } from "./create-infinite-query-options.js";
-export type { ConnectInfiniteQueryOptions } from "./create-infinite-query-options.js";
+export type {
+  ConnectInfiniteQueryOptions,
+  InfiniteQueryOptionsWithSkipToken,
+  InfiniteQueryOptions,
+} from "./create-infinite-query-options.js";
 export { createQueryOptions } from "./create-query-options.js";
+export type {
+  QueryOptions,
+  QueryOptionsWithSkipToken,
+} from "./create-query-options.js";
 export { addStaticKeyToTransport } from "./transport-key.js";
 export type { SkipToken } from "@tanstack/query-core";
 export { skipToken } from "@tanstack/query-core";


### PR DESCRIPTION
These types make it easier to create helper functions wrapping our
options.

Signed-off-by: Paul Sachs <psachs@buf.build>
