### PR TITLE
Introduce deep page key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,10 @@ Identical to useQuery but mapping to the `useSuspenseQuery` hook from [TanStack 
 function useInfiniteQuery<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input:
-    | SkipToken
-    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+  input: SkipToken | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     pageParamKey,
@@ -243,7 +241,7 @@ function useInfiniteQuery<
 
 The `useInfiniteQuery` is a wrapper around TanStack Query's [`useInfiniteQuery`](https://tanstack.com/query/v5/docs/react/reference/useInfiniteQuery) hook, but it's preconfigured with the correct `queryKey` and `queryFn` for the given method.
 
-There are some required options for `useInfiniteQuery`, primarily `pageParamKey` and `getNextPageParam`. These are required because Connect-Query doesn't know how to paginate your data. You must provide a mapping from the output of the previous page and getting the next page. All other options passed to `useInfiniteQuery` will be merged with the options that Connect-Query provides to @tanstack/react-query. This means that you can pass any additional options that TanStack Query supports.
+There are some required options for `useInfiniteQuery`, primarily `pageParamKey` and `getNextPageParam`. These are required because Connect-Query doesn't know how to paginate your data. You must provide a mapping from the output of the previous page and getting the next page. `pageParamKey` supports root keys as strings (`"page"`) and nested keys as key-path arrays (`["query", "page"]`). All other options passed to `useInfiniteQuery` will be merged with the options that Connect-Query provides to @tanstack/react-query. This means that you can pass any additional options that TanStack Query supports.
 
 ### `useSuspenseInfiniteQuery`
 
@@ -434,12 +432,10 @@ const MyComponent = () => {
 function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input:
-    | SkipToken
-    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+  input: SkipToken | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     getNextPageParam,

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ function useInfiniteQuery<
 
 The `useInfiniteQuery` is a wrapper around TanStack Query's [`useInfiniteQuery`](https://tanstack.com/query/v5/docs/react/reference/useInfiniteQuery) hook, but it's preconfigured with the correct `queryKey` and `queryFn` for the given method.
 
-There are some required options for `useInfiniteQuery`, primarily `pageParamKey` and `getNextPageParam`. These are required because Connect-Query doesn't know how to paginate your data. You must provide a mapping from the output of the previous page and getting the next page. `pageParamKey` supports root keys as strings (`"page"`) and nested keys as key-path arrays (`["query", "page"]`). All other options passed to `useInfiniteQuery` will be merged with the options that Connect-Query provides to @tanstack/react-query. This means that you can pass any additional options that TanStack Query supports.
+There are some required options for `useInfiniteQuery`, primarily `pageParamKey` and `getNextPageParam`. These are required because Connect-Query doesn't know how to paginate your data. You must provide a mapping from the output of the previous page and getting the next page. `pageParamKey` supports root keys as strings (`"page"`) and nested keys as dot-separated strings (`"query.page"`). All other options passed to `useInfiniteQuery` will be merged with the options that Connect-Query provides to @tanstack/react-query. This means that you can pass any additional options that TanStack Query supports.
 
 ### `useSuspenseInfiniteQuery`
 

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
 import type { Transport } from "@connectrpc/connect";
 import {
   ElizaService,
@@ -21,6 +22,7 @@ import {
   type SayResponse,
 } from "test-utils/gen/eliza_pb.js";
 import {
+  NestedListRequestSchema,
   ListRequestSchema,
   ListResponseSchema,
   ListService,
@@ -30,6 +32,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { createConnectQueryKey } from "./connect-query-key.js";
 import { skipToken } from "./index.js";
+import type { MessagePageParamKey } from "./index.js";
 import { createMessageKey } from "./message-key.js";
 import { createTransportKey } from "./transport-key.js";
 import { type InfiniteData, QueryClient } from "@tanstack/query-core";
@@ -81,6 +84,57 @@ describe("createConnectQueryKey", () => {
         input: createMessageKey(ListRequestSchema, {}),
       },
     ]);
+  });
+
+  it("creates a full infinite key with nested pageParamKey", () => {
+    const key = createConnectQueryKey({
+      transport: fakeTransport,
+      schema: ListService.method.nestedList,
+      input: create(NestedListRequestSchema, { nested: { page: 0n } }),
+      pageParamKey: ["nested", "page"],
+      cardinality: "infinite",
+    });
+    expect(key).toStrictEqual([
+      "connect-query",
+      {
+        transport: createTransportKey(fakeTransport),
+        serviceName: "ListService",
+        methodName: "NestedList",
+        cardinality: "infinite",
+        input: createMessageKey(NestedListRequestSchema, { nested: {} }),
+      },
+    ]);
+  });
+
+  it("rejects an invalid nested pageParamKey segment", () => {
+    type Key = MessagePageParamKey<
+      MessageInitShape<typeof NestedListRequestSchema>
+    >;
+    // @ts-expect-error(2322) nested segment must be a valid key
+    const invalidPageParamKey: Key = ["nested", "p@ge"];
+    expect(invalidPageParamKey).toBeDefined();
+  });
+
+  it("rejects array prototype key paths", () => {
+    type Key = MessagePageParamKey<{
+      nested: {
+        page: bigint;
+      };
+      items: string[];
+    }>;
+    // @ts-expect-error(2322) array prototype keys are not valid path segments
+    const invalidArrayPrototypePath: Key = ["items", "pop"];
+    expect(invalidArrayPrototypePath).toBeDefined();
+  });
+
+  it("rejects protobuf internal keys", () => {
+    type Key = MessagePageParamKey<MessageInitShape<typeof SayRequestSchema>>;
+    // @ts-expect-error(2322) protobuf internal key is not supported
+    const invalidTypeNameKey: Key = "$typeName";
+    // @ts-expect-error(2322) protobuf internal key is not supported
+    const invalidUnknownKey: Key = "$unknown";
+    expect(invalidTypeNameKey).toBeDefined();
+    expect(invalidUnknownKey).toBeDefined();
   });
 
   it("allows input: undefined", () => {

--- a/packages/connect-query-core/src/connect-query-key.test.ts
+++ b/packages/connect-query-core/src/connect-query-key.test.ts
@@ -91,7 +91,7 @@ describe("createConnectQueryKey", () => {
       transport: fakeTransport,
       schema: ListService.method.nestedList,
       input: create(NestedListRequestSchema, { nested: { page: 0n } }),
-      pageParamKey: ["nested", "page"],
+      pageParamKey: "nested.page",
       cardinality: "infinite",
     });
     expect(key).toStrictEqual([
@@ -111,7 +111,7 @@ describe("createConnectQueryKey", () => {
       MessageInitShape<typeof NestedListRequestSchema>
     >;
     // @ts-expect-error(2322) nested segment must be a valid key
-    const invalidPageParamKey: Key = ["nested", "p@ge"];
+    const invalidPageParamKey: Key = "nested.p@ge";
     expect(invalidPageParamKey).toBeDefined();
   });
 
@@ -123,7 +123,7 @@ describe("createConnectQueryKey", () => {
       items: string[];
     }>;
     // @ts-expect-error(2322) array prototype keys are not valid path segments
-    const invalidArrayPrototypePath: Key = ["items", "pop"];
+    const invalidArrayPrototypePath: Key = "items.pop";
     expect(invalidArrayPrototypePath).toBeDefined();
   });
 

--- a/packages/connect-query-core/src/connect-query-key.ts
+++ b/packages/connect-query-core/src/connect-query-key.ts
@@ -24,6 +24,7 @@ import type { ConnectError, Transport } from "@connectrpc/connect";
 import type { DataTag, InfiniteData, SkipToken } from "@tanstack/query-core";
 
 import { createMessageKey } from "./message-key.js";
+import type { MessagePageParamKey } from "./page-param-key.js";
 import { createTransportKey } from "./transport-key.js";
 
 type SharedConnectQueryOptions = {
@@ -129,7 +130,7 @@ type KeyParamsForMethod<Desc extends DescMethod> = {
   /**
    * If omit the field with this name from the key for infinite queries.
    */
-  pageParamKey?: keyof MessageInitShape<Desc["input"]>;
+  pageParamKey?: MessagePageParamKey<MessageInitShape<Desc["input"]>>;
   /**
    * Set `headers` in the key.
    * Note that invalid HTTP header names will raise a TypeError, and that the Set-Cookie header is not supported.

--- a/packages/connect-query-core/src/create-infinite-query-options.test.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.test.ts
@@ -46,7 +46,7 @@ describe("createInfiniteQueryOptions", () => {
       {
         transport: mockedElizaTransport,
         getNextPageParam: (lastPage) => (lastPage.nested?.page ?? 0n) + 1n,
-        pageParamKey: ["nested", "page"],
+        pageParamKey: "nested.page",
       },
     );
     expect(opt.initialPageParam).toBe(initialPage);

--- a/packages/connect-query-core/src/create-infinite-query-options.test.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { createInfiniteQueryOptions, skipToken } from "./index.js";
 
 const listMethod = ListService.method.list;
+const nestedListMethod = ListService.method.nestedList;
 
 const mockedElizaTransport = mockEliza();
 
@@ -31,5 +32,25 @@ describe("createInfiniteQueryOptions", () => {
     });
     expect(opt.queryFn).toBe(skipToken);
     expectTypeOf(opt.queryFn).toEqualTypeOf(skipToken);
+  });
+
+  it("allows nested pageParamKey as key path array", () => {
+    const initialPage = 10n;
+    const opt = createInfiniteQueryOptions(
+      nestedListMethod,
+      {
+        nested: {
+          page: initialPage,
+        },
+      },
+      {
+        transport: mockedElizaTransport,
+        getNextPageParam: (lastPage) => (lastPage.nested?.page ?? 0n) + 1n,
+        pageParamKey: ["nested", "page"],
+      },
+    );
+    expect(opt.initialPageParam).toBe(initialPage);
+    expect(opt.queryKey[1].input).toStrictEqual({ nested: {} });
+    expectTypeOf(opt.initialPageParam).toEqualTypeOf<bigint | undefined>();
   });
 });

--- a/packages/connect-query-core/src/create-infinite-query-options.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.ts
@@ -164,9 +164,7 @@ export function createInfiniteQueryOptions<
   const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input:
-    | SkipToken
-    | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
+  input: SkipToken | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     getNextPageParam,
@@ -182,9 +180,7 @@ export function createInfiniteQueryOptions<
   const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input:
-    | SkipToken
-    | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
+  input: SkipToken | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     getNextPageParam,

--- a/packages/connect-query-core/src/create-infinite-query-options.ts
+++ b/packages/connect-query-core/src/create-infinite-query-options.ts
@@ -31,6 +31,13 @@ import {
   type ConnectQueryKey,
   createConnectQueryKey,
 } from "./connect-query-key.js";
+import {
+  getValueAtPath,
+  type MessageInitWithPageParam,
+  type MessagePageParamKey,
+  type MessagePageParamValue,
+  setValueAtPath,
+} from "./page-param-key.js";
 import { createStructuralSharing } from "./structural-sharing.js";
 import { assert } from "./utils.js";
 
@@ -40,7 +47,7 @@ import { assert } from "./utils.js";
 export interface InfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 > {
   getNextPageParam: ConnectInfiniteQueryOptions<
     I,
@@ -51,10 +58,10 @@ export interface InfiniteQueryOptions<
   queryFn: QueryFunction<
     MessageShape<O>,
     ConnectQueryKey<O>,
-    MessageInitShape<I>[ParamKey]
+    MessagePageParamValue<MessageInitShape<I>, ParamKey>
   >;
   structuralSharing: (oldData: unknown, newData: unknown) => unknown;
-  initialPageParam: MessageInitShape<I>[ParamKey];
+  initialPageParam: MessagePageParamValue<MessageInitShape<I>, ParamKey>;
 }
 
 /**
@@ -63,7 +70,7 @@ export interface InfiniteQueryOptions<
 export interface InfiniteQueryOptionsWithSkipToken<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 > extends Omit<InfiniteQueryOptions<I, O, ParamKey>, "queryFn"> {
   queryFn: SkipToken;
 }
@@ -74,13 +81,13 @@ export interface InfiniteQueryOptionsWithSkipToken<
 export interface ConnectInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 > {
   /** Defines which part of the input should be considered the page param */
   pageParamKey: ParamKey;
   /** Determines the next page. */
   getNextPageParam: GetNextPageParamFunction<
-    MessageInitShape<I>[ParamKey],
+    MessagePageParamValue<MessageInitShape<I>, ParamKey>,
     MessageShape<O>
   >;
   headers?: HeadersInit;
@@ -90,7 +97,7 @@ export interface ConnectInfiniteQueryOptions<
 function createUnaryInfiniteQueryFn<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   transport: Transport,
   schema: DescMethodUnary<I, O>,
@@ -103,15 +110,16 @@ function createUnaryInfiniteQueryFn<
 ): QueryFunction<
   MessageShape<O>,
   ConnectQueryKey<O>,
-  MessageInitShape<I>[ParamKey]
+  MessagePageParamValue<MessageInitShape<I>, ParamKey>
 > {
   return async (context) => {
     assert("pageParam" in context, "pageParam must be part of context");
 
-    const inputCombinedWithPageParam = {
-      ...input,
-      [pageParamKey]: context.pageParam,
-    };
+    const inputCombinedWithPageParam = setValueAtPath(
+      input,
+      pageParamKey as MessagePageParamKey<Record<string, unknown>>,
+      context.pageParam,
+    ) as MessageInitShape<I>;
     return callUnaryMethod(transport, schema, inputCombinedWithPageParam, {
       signal: context.signal,
       headers: context.queryKey[1].headers,
@@ -125,10 +133,10 @@ function createUnaryInfiniteQueryFn<
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input: MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>,
+  input: MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     getNextPageParam,
@@ -139,7 +147,7 @@ export function createInfiniteQueryOptions<
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
   input: SkipToken,
@@ -153,12 +161,12 @@ export function createInfiniteQueryOptions<
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
   input:
     | SkipToken
-    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+    | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     getNextPageParam,
@@ -171,12 +179,12 @@ export function createInfiniteQueryOptions<
 export function createInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
   input:
     | SkipToken
-    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+    | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     getNextPageParam,
@@ -205,8 +213,11 @@ export function createInfiniteQueryOptions<
     getNextPageParam,
     initialPageParam:
       input === skipToken
-        ? (undefined as MessageInitShape<I>[ParamKey])
-        : (input[pageParamKey] as MessageInitShape<I>[ParamKey]),
+        ? (undefined as MessagePageParamValue<MessageInitShape<I>, ParamKey>)
+        : (getValueAtPath(
+            input,
+            pageParamKey as MessagePageParamKey<Record<string, unknown>>,
+          ) as MessagePageParamValue<MessageInitShape<I>, ParamKey>),
     queryKey,
     queryFn,
     structuralSharing,

--- a/packages/connect-query-core/src/index.ts
+++ b/packages/connect-query-core/src/index.ts
@@ -23,6 +23,11 @@ export type {
   InfiniteQueryOptionsWithSkipToken,
   InfiniteQueryOptions,
 } from "./create-infinite-query-options.js";
+export type {
+  MessageInitWithPageParam,
+  MessagePageParamKey,
+  MessagePageParamValue,
+} from "./page-param-key.js";
 export { createQueryOptions } from "./create-query-options.js";
 export type {
   QueryOptions,

--- a/packages/connect-query-core/src/message-key.test.ts
+++ b/packages/connect-query-core/src/message-key.test.ts
@@ -53,7 +53,7 @@ describe("message key", () => {
           stringField: "abc",
         },
       },
-      ["messageField", "int32Field"],
+      "messageField.int32Field",
     );
     expect(key).toStrictEqual({
       messageField: {

--- a/packages/connect-query-core/src/message-key.test.ts
+++ b/packages/connect-query-core/src/message-key.test.ts
@@ -43,6 +43,24 @@ describe("message key", () => {
       stringField: "abc",
     });
   });
+
+  it("omits nested pageParamKey", () => {
+    const key = createMessageKey(
+      Proto3MessageSchema,
+      {
+        messageField: {
+          int32Field: 1,
+          stringField: "abc",
+        },
+      },
+      ["messageField", "int32Field"],
+    );
+    expect(key).toStrictEqual({
+      messageField: {
+        stringField: "abc",
+      },
+    });
+  });
   it("converts as expected", () => {
     const key = createMessageKey(Proto3MessageSchema, {
       int64Field: 123n,

--- a/packages/connect-query-core/src/message-key.ts
+++ b/packages/connect-query-core/src/message-key.ts
@@ -22,6 +22,11 @@ import type {
 import { reflect } from "@bufbuild/protobuf/reflect";
 import { base64Encode } from "@bufbuild/protobuf/wire";
 
+import {
+  pageParamPathSegments,
+  type MessagePageParamKey,
+} from "./page-param-key.js";
+
 /**
  * For any given message, create an object that is suitable for a Query Key in
  * TanStack Query:
@@ -37,17 +42,19 @@ import { base64Encode } from "@bufbuild/protobuf/wire";
  */
 export function createMessageKey<
   Desc extends DescMessage,
-  PageParamKey extends keyof MessageInitShape<Desc>,
+  PageParamKey extends MessagePageParamKey<MessageInitShape<Desc>>,
 >(
   schema: Desc,
   value: MessageInitShape<Desc>,
   pageParamKey?: PageParamKey,
 ): Record<string, unknown> {
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- circular reference
-  return messageKey(
-    reflect(schema, create(schema, value)),
-    pageParamKey?.toString(),
-  );
+  const pageParamPath =
+    pageParamKey === undefined
+      ? undefined
+      : pageParamPathSegments(
+          pageParamKey as MessagePageParamKey<Record<string, unknown>>,
+        );
+  return messageKey(reflect(schema, create(schema, value)), pageParamPath);
 }
 
 function scalarKey(value: unknown): unknown {
@@ -99,14 +106,16 @@ function mapKey(map: ReflectMap): Record<string, unknown> {
 
 function messageKey(
   message: ReflectMessage,
-  pageParamKey?: string,
+  pageParamPath?: string[],
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const f of message.sortedFields) {
     if (!message.isSet(f)) {
       continue;
     }
-    if (f.localName === pageParamKey) {
+    const includesPageParam =
+      pageParamPath !== undefined && f.localName === pageParamPath[0];
+    if (includesPageParam && pageParamPath.length === 1) {
       continue;
     }
     switch (f.fieldKind) {
@@ -123,7 +132,10 @@ function messageKey(
         result[f.localName] = mapKey(message.get(f));
         break;
       case "message":
-        result[f.localName] = messageKey(message.get(f));
+        result[f.localName] = messageKey(
+          message.get(f),
+          includesPageParam ? pageParamPath.slice(1) : undefined,
+        );
         break;
     }
   }

--- a/packages/connect-query-core/src/page-param-key.ts
+++ b/packages/connect-query-core/src/page-param-key.ts
@@ -23,58 +23,44 @@ type CanDescend<T> = T extends readonly unknown[]
     ? true
     : false;
 
-type MessagePageParamPathTuple<
-  T,
-  Depth extends number = 5,
-> = Depth extends 0
+type MessagePageParamPathString<T, Depth extends number = 5> = Depth extends 0
   ? never
   : T extends object
     ? {
         [K in StringKeyOf<T>]: CanDescend<NonNullable<T[K]>> extends true
           ?
-              | readonly [K]
-              | readonly [
-                  K,
-                  ...MessagePageParamPathTuple<
-                    NonNullable<T[K]>,
-                    PrevDepth[Depth]
-                  >,
-                ]
-          : readonly [K];
+              | K
+              | `${K}.${MessagePageParamPathString<
+                  NonNullable<T[K]>,
+                  PrevDepth[Depth]
+                >}`
+          : K;
       }[StringKeyOf<T>]
     : never;
 
 /**
  * A page param key can be a root key,
- * or an array-based key path.
+ * or a dot-separated key path.
  */
-export type MessagePageParamKey<T> =
-  | StringKeyOf<T>
-  | MessagePageParamPathTuple<T>;
+export type MessagePageParamKey<T> = MessagePageParamPathString<T>;
 
-type SegmentsPathValue<T, P extends readonly [string, ...string[]]> =
-  P extends readonly [
-  infer Head extends string,
-  ...infer Tail extends string[],
-]
+type DotPathValue<T, P extends string> = P extends `${infer Head}.${infer Tail}`
   ? Head extends StringKeyOf<T>
-    ? Tail extends readonly [string, ...string[]]
-      ? SegmentsPathValue<NonNullable<T[Head]>, Tail>
-      : T[Head]
+    ? DotPathValue<NonNullable<T[Head]>, Tail>
     : never
-  : never;
+  : P extends StringKeyOf<T>
+    ? T[P]
+    : never;
 
 /**
  * Resolves the value type at a page param key path.
  */
-export type MessagePageParamValue<T, K extends MessagePageParamKey<T>> =
-  K extends readonly [string, ...string[]]
-    ? SegmentsPathValue<T, K>
-    : K extends StringKeyOf<T>
-      ? T[K]
-      : never;
+export type MessagePageParamValue<
+  T,
+  K extends MessagePageParamKey<T>,
+> = K extends string ? DotPathValue<T, K> : never;
 
-type RootKey<K> = K extends readonly [infer Head extends string, ...string[]]
+type RootKey<K> = K extends `${infer Head}.${string}`
   ? Head
   : K extends StringKeyOf<Record<string, unknown>>
     ? K
@@ -83,13 +69,13 @@ type RootKey<K> = K extends readonly [infer Head extends string, ...string[]]
 /**
  * Requires the root object key for a page param path.
  */
-export type MessageInitWithPageParam<T, K extends MessagePageParamKey<T>> =
-  T & Required<Pick<T, Extract<RootKey<K>, StringKeyOf<T>>>>;
+export type MessageInitWithPageParam<T, K extends MessagePageParamKey<T>> = T &
+  Required<Pick<T, Extract<RootKey<K>, StringKeyOf<T>>>>;
 
 export function pageParamPathSegments(
   pageParamKey: MessagePageParamKey<Record<string, unknown>>,
 ): string[] {
-  return typeof pageParamKey === "string" ? [pageParamKey] : [...pageParamKey];
+  return pageParamKey.split(".");
 }
 
 export function getValueAtPath(
@@ -99,7 +85,11 @@ export function getValueAtPath(
   const path = pageParamPathSegments(pageParamKey);
   let current: unknown = value;
   for (const segment of path) {
-    if (typeof current !== "object" || current === null || !(segment in current)) {
+    if (
+      typeof current !== "object" ||
+      current === null ||
+      !(segment in current)
+    ) {
       return undefined;
     }
     current = (current as Record<string, unknown>)[segment];

--- a/packages/connect-query-core/src/page-param-key.ts
+++ b/packages/connect-query-core/src/page-param-key.ts
@@ -1,0 +1,135 @@
+// Copyright 2021-2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Message } from "@bufbuild/protobuf";
+
+type StringKeyOf<T> = Exclude<Extract<keyof T, string>, keyof Message>;
+type PrevDepth = [never, 0, 1, 2, 3, 4, 5];
+
+type CanDescend<T> = T extends readonly unknown[]
+  ? false
+  : T extends object
+    ? true
+    : false;
+
+type MessagePageParamPathTuple<
+  T,
+  Depth extends number = 5,
+> = Depth extends 0
+  ? never
+  : T extends object
+    ? {
+        [K in StringKeyOf<T>]: CanDescend<NonNullable<T[K]>> extends true
+          ?
+              | readonly [K]
+              | readonly [
+                  K,
+                  ...MessagePageParamPathTuple<
+                    NonNullable<T[K]>,
+                    PrevDepth[Depth]
+                  >,
+                ]
+          : readonly [K];
+      }[StringKeyOf<T>]
+    : never;
+
+/**
+ * A page param key can be a root key,
+ * or an array-based key path.
+ */
+export type MessagePageParamKey<T> =
+  | StringKeyOf<T>
+  | MessagePageParamPathTuple<T>;
+
+type SegmentsPathValue<T, P extends readonly [string, ...string[]]> =
+  P extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? Head extends StringKeyOf<T>
+    ? Tail extends readonly [string, ...string[]]
+      ? SegmentsPathValue<NonNullable<T[Head]>, Tail>
+      : T[Head]
+    : never
+  : never;
+
+/**
+ * Resolves the value type at a page param key path.
+ */
+export type MessagePageParamValue<T, K extends MessagePageParamKey<T>> =
+  K extends readonly [string, ...string[]]
+    ? SegmentsPathValue<T, K>
+    : K extends StringKeyOf<T>
+      ? T[K]
+      : never;
+
+type RootKey<K> = K extends readonly [infer Head extends string, ...string[]]
+  ? Head
+  : K extends StringKeyOf<Record<string, unknown>>
+    ? K
+    : never;
+
+/**
+ * Requires the root object key for a page param path.
+ */
+export type MessageInitWithPageParam<T, K extends MessagePageParamKey<T>> =
+  T & Required<Pick<T, Extract<RootKey<K>, StringKeyOf<T>>>>;
+
+export function pageParamPathSegments(
+  pageParamKey: MessagePageParamKey<Record<string, unknown>>,
+): string[] {
+  return typeof pageParamKey === "string" ? [pageParamKey] : [...pageParamKey];
+}
+
+export function getValueAtPath(
+  value: Record<string, unknown>,
+  pageParamKey: MessagePageParamKey<Record<string, unknown>>,
+): unknown {
+  const path = pageParamPathSegments(pageParamKey);
+  let current: unknown = value;
+  for (const segment of path) {
+    if (typeof current !== "object" || current === null || !(segment in current)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export function setValueAtPath(
+  value: Record<string, unknown>,
+  pageParamKey: MessagePageParamKey<Record<string, unknown>>,
+  pageParam: unknown,
+): Record<string, unknown> {
+  const path = pageParamPathSegments(pageParamKey);
+  const result: Record<string, unknown> = { ...value };
+  let source: Record<string, unknown> = value;
+  let target = result;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    const sourceNext = source[key];
+    const targetNext =
+      typeof sourceNext === "object" && sourceNext !== null
+        ? { ...(sourceNext as Record<string, unknown>) }
+        : {};
+    target[key] = targetNext;
+    target = targetNext;
+    source =
+      typeof sourceNext === "object" && sourceNext !== null
+        ? (sourceNext as Record<string, unknown>)
+        : {};
+  }
+  target[path[path.length - 1]] = pageParam;
+  return result;
+}

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -16,9 +16,13 @@ import { create } from "@bufbuild/protobuf";
 import { createConnectQueryKey } from "@connectrpc/connect-query-core";
 import { QueryCache, skipToken } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
-import { mockPaginatedTransport } from "test-utils";
+import {
+  mockNestedPaginatedTransport,
+  mockPaginatedTransport,
+} from "test-utils";
 import {
   ListRequestSchema,
+  NestedListRequestSchema,
   ListResponseSchema,
   ListService,
 } from "test-utils/gen/list_pb.js";
@@ -33,8 +37,10 @@ import { useQuery } from "./use-query.js";
 
 // TODO: maybe create a helper to take a service and method and generate this.
 const methodDescriptor = ListService.method.list;
+const nestedMethodDescriptor = ListService.method.nestedList;
 
 const mockedPaginatedTransport = mockPaginatedTransport();
+const mockedNestedPaginatedTransport = mockNestedPaginatedTransport();
 
 describe("useInfiniteQuery", () => {
   it("can query paginated data", async () => {
@@ -339,6 +345,66 @@ describe("useInfiniteQuery", () => {
       pageParamKey: "page",
       input: create(ListRequestSchema, {
         preview: true,
+      }),
+    });
+    expect(
+      wrapperOpts.queryClient.getQueryData(manuallyCreatedQueryKey),
+    ).toEqual(result.current.data);
+  });
+
+  it("builds nested page input for successive pages", async () => {
+    const wrapperOpts = wrapper({}, mockedNestedPaginatedTransport);
+    const { result } = renderHook(() => {
+      return useInfiniteQuery(
+        nestedMethodDescriptor,
+        {
+          nested: {
+            page: 1n,
+            preview: true,
+          },
+        },
+        {
+          getNextPageParam: (lastPage) => (lastPage.nested?.page ?? 0n) + 1n,
+          pageParamKey: ["nested", "page"],
+        },
+      );
+    }, wrapperOpts);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+
+    expect(result.current.data?.pageParams).toEqual([1n]);
+    expect(result.current.data?.pages.map((page) => page.nested?.page)).toEqual([
+      1n,
+    ]);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeFalsy();
+    });
+
+    await result.current.fetchNextPage();
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeFalsy();
+    });
+
+    expect(result.current.data?.pageParams).toEqual([1n, 2n, 3n]);
+    expect(result.current.data?.pages.map((page) => page.nested?.page)).toEqual([
+      1n,
+      2n,
+      3n,
+    ]);
+
+    const manuallyCreatedQueryKey = createConnectQueryKey({
+      schema: nestedMethodDescriptor,
+      transport: mockedNestedPaginatedTransport,
+      cardinality: "infinite",
+      pageParamKey: ["nested", "page"],
+      input: create(NestedListRequestSchema, {
+        nested: {
+          preview: true,
+        },
       }),
     });
     expect(

--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -22,7 +22,6 @@ import {
 } from "test-utils";
 import {
   ListRequestSchema,
-  NestedListRequestSchema,
   ListResponseSchema,
   ListService,
 } from "test-utils/gen/list_pb.js";
@@ -365,7 +364,7 @@ describe("useInfiniteQuery", () => {
         },
         {
           getNextPageParam: (lastPage) => (lastPage.nested?.page ?? 0n) + 1n,
-          pageParamKey: ["nested", "page"],
+          pageParamKey: "nested.page",
         },
       );
     }, wrapperOpts);
@@ -375,9 +374,9 @@ describe("useInfiniteQuery", () => {
     });
 
     expect(result.current.data?.pageParams).toEqual([1n]);
-    expect(result.current.data?.pages.map((page) => page.nested?.page)).toEqual([
-      1n,
-    ]);
+    expect(result.current.data?.pages.map((page) => page.nested?.page)).toEqual(
+      [1n],
+    );
 
     await result.current.fetchNextPage();
     await waitFor(() => {
@@ -390,22 +389,21 @@ describe("useInfiniteQuery", () => {
     });
 
     expect(result.current.data?.pageParams).toEqual([1n, 2n, 3n]);
-    expect(result.current.data?.pages.map((page) => page.nested?.page)).toEqual([
-      1n,
-      2n,
-      3n,
-    ]);
+    expect(result.current.data?.pages.map((page) => page.nested?.page)).toEqual(
+      [1n, 2n, 3n],
+    );
 
     const manuallyCreatedQueryKey = createConnectQueryKey({
       schema: nestedMethodDescriptor,
       transport: mockedNestedPaginatedTransport,
       cardinality: "infinite",
-      pageParamKey: ["nested", "page"],
-      input: create(NestedListRequestSchema, {
+      pageParamKey: "nested.page",
+      input: {
         nested: {
+          page: 1n,
           preview: true,
         },
-      }),
+      },
     });
     expect(
       wrapperOpts.queryClient.getQueryData(manuallyCreatedQueryKey),

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -22,6 +22,9 @@ import type { ConnectError, Transport } from "@connectrpc/connect";
 import type {
   ConnectInfiniteQueryOptions,
   ConnectQueryKey,
+  MessageInitWithPageParam,
+  MessagePageParamKey,
+  MessagePageParamValue,
 } from "@connectrpc/connect-query-core";
 import { createInfiniteQueryOptions } from "@connectrpc/connect-query-core";
 import type {
@@ -45,14 +48,14 @@ import { useTransport } from "./use-transport.js";
 export type UseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 > = Omit<
   TanStackUseInfiniteQueryOptions<
     MessageShape<O>,
     ConnectError,
     InfiniteData<MessageShape<O>>,
     ConnectQueryKey<O>,
-    MessageInitShape<I>[ParamKey]
+    MessagePageParamValue<MessageInitShape<I>, ParamKey>
   >,
   "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
 > &
@@ -67,12 +70,12 @@ export type UseInfiniteQueryOptions<
 export function useInfiniteQuery<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
   input:
     | SkipToken
-    | (MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>),
+    | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     pageParamKey,
@@ -98,14 +101,14 @@ export function useInfiniteQuery<
 export type UseSuspenseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 > = Omit<
   TanStackUseSuspenseInfiniteQueryOptions<
     MessageShape<O>,
     ConnectError,
     InfiniteData<MessageShape<O>>,
     ConnectQueryKey<O>,
-    MessageInitShape<I>[ParamKey]
+    MessagePageParamValue<MessageInitShape<I>, ParamKey>
   >,
   "getNextPageParam" | "initialPageParam" | "queryFn" | "queryKey"
 > &
@@ -120,10 +123,10 @@ export type UseSuspenseInfiniteQueryOptions<
 export function useSuspenseInfiniteQuery<
   I extends DescMessage,
   O extends DescMessage,
-  ParamKey extends keyof MessageInitShape<I>,
+  const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input: MessageInitShape<I> & Required<Pick<MessageInitShape<I>, ParamKey>>,
+  input: MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     pageParamKey,

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -73,9 +73,7 @@ export function useInfiniteQuery<
   const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
 >(
   schema: DescMethodUnary<I, O>,
-  input:
-    | SkipToken
-    | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
+  input: SkipToken | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
   {
     transport,
     pageParamKey,

--- a/packages/test-utils/proto/list.proto
+++ b/packages/test-utils/proto/list.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 service ListService {
   rpc List(ListRequest) returns (ListResponse);
+  rpc NestedList(NestedListRequest) returns (NestedListResponse);
 }
 
 message ListRequest {
@@ -28,3 +29,18 @@ message ListResponse {
   repeated string items = 2;
 }
 
+message NestedListRequest {
+  message Nested {
+    int64 page = 1;
+    bool preview = 2;
+  }
+  Nested nested = 1;
+}
+
+message NestedListResponse {
+  message Nested {
+    int64 page = 1;
+  }
+  Nested nested = 1;
+  repeated string items = 2;
+}

--- a/packages/test-utils/src/gen/list_pb.ts
+++ b/packages/test-utils/src/gen/list_pb.ts
@@ -24,7 +24,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file list.proto.
  */
 export const file_list: GenFile = /*@__PURE__*/
-  fileDesc("CgpsaXN0LnByb3RvIiwKC0xpc3RSZXF1ZXN0EgwKBHBhZ2UYASABKAMSDwoHcHJldmlldxgCIAEoCCIrCgxMaXN0UmVzcG9uc2USDAoEcGFnZRgBIAEoAxINCgVpdGVtcxgCIAMoCTIyCgtMaXN0U2VydmljZRIjCgRMaXN0EgwuTGlzdFJlcXVlc3QaDS5MaXN0UmVzcG9uc2ViBnByb3RvMw");
+  fileDesc("CgpsaXN0LnByb3RvIiwKC0xpc3RSZXF1ZXN0EgwKBHBhZ2UYASABKAMSDwoHcHJldmlldxgCIAEoCCIrCgxMaXN0UmVzcG9uc2USDAoEcGFnZRgBIAEoAxINCgVpdGVtcxgCIAMoCSJnChFOZXN0ZWRMaXN0UmVxdWVzdBIpCgZuZXN0ZWQYASABKAsyGS5OZXN0ZWRMaXN0UmVxdWVzdC5OZXN0ZWQaJwoGTmVzdGVkEgwKBHBhZ2UYASABKAMSDwoHcHJldmlldxgCIAEoCCJnChJOZXN0ZWRMaXN0UmVzcG9uc2USKgoGbmVzdGVkGAEgASgLMhouTmVzdGVkTGlzdFJlc3BvbnNlLk5lc3RlZBINCgVpdGVtcxgCIAMoCRoWCgZOZXN0ZWQSDAoEcGFnZRgBIAEoAzJpCgtMaXN0U2VydmljZRIjCgRMaXN0EgwuTGlzdFJlcXVlc3QaDS5MaXN0UmVzcG9uc2USNQoKTmVzdGVkTGlzdBISLk5lc3RlZExpc3RSZXF1ZXN0GhMuTmVzdGVkTGlzdFJlc3BvbnNlYgZwcm90bzM");
 
 /**
  * @generated from message ListRequest
@@ -71,6 +71,84 @@ export const ListResponseSchema: GenMessage<ListResponse> = /*@__PURE__*/
   messageDesc(file_list, 1);
 
 /**
+ * @generated from message NestedListRequest
+ */
+export type NestedListRequest = Message<"NestedListRequest"> & {
+  /**
+   * @generated from field: NestedListRequest.Nested nested = 1;
+   */
+  nested?: NestedListRequest_Nested;
+};
+
+/**
+ * Describes the message NestedListRequest.
+ * Use `create(NestedListRequestSchema)` to create a new message.
+ */
+export const NestedListRequestSchema: GenMessage<NestedListRequest> = /*@__PURE__*/
+  messageDesc(file_list, 2);
+
+/**
+ * @generated from message NestedListRequest.Nested
+ */
+export type NestedListRequest_Nested = Message<"NestedListRequest.Nested"> & {
+  /**
+   * @generated from field: int64 page = 1;
+   */
+  page: bigint;
+
+  /**
+   * @generated from field: bool preview = 2;
+   */
+  preview: boolean;
+};
+
+/**
+ * Describes the message NestedListRequest.Nested.
+ * Use `create(NestedListRequest_NestedSchema)` to create a new message.
+ */
+export const NestedListRequest_NestedSchema: GenMessage<NestedListRequest_Nested> = /*@__PURE__*/
+  messageDesc(file_list, 2, 0);
+
+/**
+ * @generated from message NestedListResponse
+ */
+export type NestedListResponse = Message<"NestedListResponse"> & {
+  /**
+   * @generated from field: NestedListResponse.Nested nested = 1;
+   */
+  nested?: NestedListResponse_Nested;
+
+  /**
+   * @generated from field: repeated string items = 2;
+   */
+  items: string[];
+};
+
+/**
+ * Describes the message NestedListResponse.
+ * Use `create(NestedListResponseSchema)` to create a new message.
+ */
+export const NestedListResponseSchema: GenMessage<NestedListResponse> = /*@__PURE__*/
+  messageDesc(file_list, 3);
+
+/**
+ * @generated from message NestedListResponse.Nested
+ */
+export type NestedListResponse_Nested = Message<"NestedListResponse.Nested"> & {
+  /**
+   * @generated from field: int64 page = 1;
+   */
+  page: bigint;
+};
+
+/**
+ * Describes the message NestedListResponse.Nested.
+ * Use `create(NestedListResponse_NestedSchema)` to create a new message.
+ */
+export const NestedListResponse_NestedSchema: GenMessage<NestedListResponse_Nested> = /*@__PURE__*/
+  messageDesc(file_list, 3, 0);
+
+/**
  * @generated from service ListService
  */
 export const ListService: GenService<{
@@ -81,6 +159,14 @@ export const ListService: GenService<{
     methodKind: "unary";
     input: typeof ListRequestSchema;
     output: typeof ListResponseSchema;
+  },
+  /**
+   * @generated from rpc ListService.NestedList
+   */
+  nestedList: {
+    methodKind: "unary";
+    input: typeof NestedListRequestSchema;
+    output: typeof NestedListResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_list, 0);

--- a/packages/test-utils/src/index.tsx
+++ b/packages/test-utils/src/index.tsx
@@ -29,7 +29,11 @@ import {
   type SayRequest,
   SayResponseSchema,
 } from "./gen/eliza_pb.js";
-import { type ListResponseSchema, ListService } from "./gen/list_pb.js";
+import {
+  type ListResponseSchema,
+  ListService,
+  type NestedListResponseSchema,
+} from "./gen/list_pb.js";
 
 /**
  * A test-only helper to increase time (necessary for testing react-query)
@@ -128,6 +132,46 @@ export const mockPaginatedTransport = (
             ],
           };
           return result;
+        },
+      });
+    },
+    {
+      router: options?.router,
+    },
+  );
+
+/**
+ * a mock for nested paginated list queries
+ */
+export const mockNestedPaginatedTransport = (
+  override?: MessageInitShape<typeof NestedListResponseSchema>,
+  addDelay = false,
+  options?: {
+    router?: ConnectRouterOptions;
+  },
+) =>
+  createRouterTransport(
+    ({ service }) => {
+      service(ListService, {
+        nestedList: async (request) => {
+          if (addDelay) {
+            await sleep(1000);
+          }
+          if (override !== undefined) {
+            return override;
+          }
+          const page = request.nested?.page ?? 0n;
+          const base = (page - 1n) * 3n;
+          return {
+            nested: {
+              page,
+            },
+            items: [
+              `${base + 1n} Item`,
+              `${base + 2n} Item`,
+              `${base + 3n} Item`,
+            ],
+          };
         },
       });
     },


### PR DESCRIPTION
Introduces the ability to use page key params that aren't just at the top of the input param. We now support dot separated keys and enforce type safety on their values. 

Fixes #569 