### PR TITLE
Improve return type of useInfiniteQuery

### DIFF
--- a/packages/connect-query/src/use-infinite-query.test.ts
+++ b/packages/connect-query/src/use-infinite-query.test.ts
@@ -164,6 +164,46 @@ describe("useInfiniteQuery", () => {
     expect(result.current.data?.pages[0].page).toEqual(-1n);
   });
 
+  it("can be used along with the select", async () => {
+    const { result } = renderHook(
+      () => {
+        return useInfiniteQuery(
+          methodDescriptor,
+          {
+            page: 0n,
+          },
+          {
+            select: ({ pages, pageParams }) => ({
+              pages: pages.map((p) => p.items.join(",")),
+              pageParams: pageParams.map((p) => p?.toString()),
+            }),
+            getNextPageParam: (lastPage) => lastPage.page + 1n,
+            pageParamKey: "page",
+          },
+        );
+      },
+      wrapper({}, mockedPaginatedTransport),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy();
+    });
+    expect(result.current.data).toEqual({
+      pageParams: ["0"],
+      pages: ["-2 Item,-1 Item,0 Item"],
+    });
+
+    await result.current.fetchNextPage();
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeFalsy();
+    });
+    expect(result.current.data).toEqual({
+      pageParams: ["0", "1"],
+      pages: ["-2 Item,-1 Item,0 Item", "1 Item,2 Item,3 Item"],
+    });
+  });
+
   it("page param doesn't persist to the query cache", async () => {
     const { queryClient, ...remainingWrapper } = wrapper(
       {},

--- a/packages/connect-query/src/use-infinite-query.ts
+++ b/packages/connect-query/src/use-infinite-query.ts
@@ -49,11 +49,13 @@ export type UseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
+  SelectOutData = MessageShape<O>,
+  SelectOutPageParam = unknown,
 > = Omit<
   TanStackUseInfiniteQueryOptions<
     MessageShape<O>,
     ConnectError,
-    InfiniteData<MessageShape<O>>,
+    InfiniteData<SelectOutData, SelectOutPageParam>,
     ConnectQueryKey<O>,
     MessagePageParamValue<MessageInitShape<I>, ParamKey>
   >,
@@ -71,6 +73,8 @@ export function useInfiniteQuery<
   I extends DescMessage,
   O extends DescMessage,
   const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
+  SelectOutData = MessageShape<O>,
+  SelectOutPageParam = unknown,
 >(
   schema: DescMethodUnary<I, O>,
   input: SkipToken | MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
@@ -79,8 +83,11 @@ export function useInfiniteQuery<
     pageParamKey,
     getNextPageParam,
     ...queryOptions
-  }: UseInfiniteQueryOptions<I, O, ParamKey>,
-): UseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> {
+  }: UseInfiniteQueryOptions<I, O, ParamKey, SelectOutData, SelectOutPageParam>,
+): UseInfiniteQueryResult<
+  InfiniteData<SelectOutData, SelectOutPageParam>,
+  ConnectError
+> {
   const transportFromCtx = useTransport();
   const baseOptions = createInfiniteQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,
@@ -100,11 +107,13 @@ export type UseSuspenseInfiniteQueryOptions<
   I extends DescMessage,
   O extends DescMessage,
   ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
+  SelectOutData = MessageShape<O>,
+  SelectOutPageParam = unknown,
 > = Omit<
   TanStackUseSuspenseInfiniteQueryOptions<
     MessageShape<O>,
     ConnectError,
-    InfiniteData<MessageShape<O>>,
+    InfiniteData<SelectOutData, SelectOutPageParam>,
     ConnectQueryKey<O>,
     MessagePageParamValue<MessageInitShape<I>, ParamKey>
   >,
@@ -122,6 +131,8 @@ export function useSuspenseInfiniteQuery<
   I extends DescMessage,
   O extends DescMessage,
   const ParamKey extends MessagePageParamKey<MessageInitShape<I>>,
+  SelectOutData = MessageShape<O>,
+  SelectOutPageParam = unknown,
 >(
   schema: DescMethodUnary<I, O>,
   input: MessageInitWithPageParam<MessageInitShape<I>, ParamKey>,
@@ -131,8 +142,17 @@ export function useSuspenseInfiniteQuery<
     getNextPageParam,
     headers,
     ...queryOptions
-  }: UseSuspenseInfiniteQueryOptions<I, O, ParamKey>,
-): UseSuspenseInfiniteQueryResult<InfiniteData<MessageShape<O>>, ConnectError> {
+  }: UseSuspenseInfiniteQueryOptions<
+    I,
+    O,
+    ParamKey,
+    SelectOutData,
+    SelectOutPageParam
+  >,
+): UseSuspenseInfiniteQueryResult<
+  InfiniteData<SelectOutData, SelectOutPageParam>,
+  ConnectError
+> {
   const transportFromCtx = useTransport();
   const baseOptions = createInfiniteQueryOptions(schema, input, {
     transport: transport ?? transportFromCtx,


### PR DESCRIPTION
Add SelectOutData and SelectOutPageParam type variables and modify the return type to use them. This change fixes the type errors that happen when the select option is used and the select function returns pages or pageParams of different types.